### PR TITLE
Created CompanyUnlockService, modified company squad update to key off available_unit_id

### DIFF
--- a/app/api/omg/company_unlocks.rb
+++ b/app/api/omg/company_unlocks.rb
@@ -12,6 +12,18 @@ module OMG
         company_unlocks = CompanyUnlock.where(company_id: params[:id])
         present company_unlocks
       end
+
+      desc 'purchase a doctrine unlock'
+      params do
+        requires :doctrine_unlock_id, type: Integer, desc: "Doctrine unlock to purchase for the company"
+      end
+      post do
+        declared_params = declared(params)
+        company = Company.includes(:company_unlocks, :squads, :ruleset, :available_units).find_by(id: declared_params[:id], player: current_player)
+        doctrine_unlock = DoctrineUnlock.includes(:unlock).find(declared_params[:doctrine_unlock_id])
+        service = CompanyUnlockService.new(company)
+        service.purchase_doctrine_unlock(doctrine_unlock)
+      end
     end
   end
 end

--- a/app/api/omg/company_unlocks.rb
+++ b/app/api/omg/company_unlocks.rb
@@ -1,0 +1,17 @@
+module OMG
+  class CompanyUnlocks < Grape::API
+    helpers OMG::Helpers
+
+    before do
+      authenticate!
+    end
+
+    resource :unlocks do
+      desc 'get all company unlocks'
+      get do
+        company_unlocks = CompanyUnlock.where(company_id: params[:id])
+        present company_unlocks
+      end
+    end
+  end
+end

--- a/app/api/omg/doctrines.rb
+++ b/app/api/omg/doctrines.rb
@@ -2,22 +2,28 @@ module OMG
   class Doctrines < Grape::API
     helpers OMG::Helpers
 
-    before do
-      authenticate!
-    end
-
     resource :doctrines do
       desc 'get all doctrines'
       get do
         present Doctrine.all
       end
 
-      desc 'get requested doctrine'
-      params do
-        requires :id, type: Integer, desc: "A doctrine ID"
-      end
-      get ':id' do
-        present Doctrine.find(params[:id])
+      route_param :id, type: Integer do
+        desc 'get requested doctrine'
+        params do
+          requires :id, type: Integer, desc: "Company ID"
+        end
+        get do
+          present Doctrine.find(params[:id])
+        end
+
+        desc 'get unlocks for the doctrine'
+        params do
+          requires :id, type: Integer, desc: "Company ID"
+        end
+        get 'unlocks' do
+          present Doctrine.find(params[:id]).doctrine_unlocks
+        end
       end
     end
   end

--- a/app/javascript/features/companies/manage/AvailableUnitDetails.jsx
+++ b/app/javascript/features/companies/manage/AvailableUnitDetails.jsx
@@ -5,7 +5,7 @@ import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import { useDispatch, useSelector } from "react-redux";
 import { fetchUnitById, selectUnitById } from "../../units/unitsSlice";
 import {
-  selectAvailableUnitByUnitId,
+  selectAvailableUnitById,
   selectAllAvailableUnits,
   selectAvailableUnitsStatus
 } from "../../units/availableUnitsSlice";
@@ -23,13 +23,13 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-export const UnitDetails = ({ unitId, unitImage }) => {
+export const AvailableUnitDetails = ({ unitId, availableUnitId, unitImage }) => {
   const classes = useStyles()
   const dispatch = useDispatch()
 
   const selectedUnitDetails = useSelector(state => selectUnitById(state, unitId))
   const availableUnitsStatus = useSelector(selectAvailableUnitsStatus)
-  const availableUnit = useSelector(state => selectAvailableUnitByUnitId(state, unitId))
+  const availableUnit = useSelector(state => selectAvailableUnitById(state, availableUnitId))
   const isAvailableUnitsReady = availableUnitsStatus !== "pending"
 
 

--- a/app/javascript/features/companies/manage/AvailableUnitDroppable.jsx
+++ b/app/javascript/features/companies/manage/AvailableUnitDroppable.jsx
@@ -62,7 +62,7 @@ export const AvailableUnitDroppable = ({
       <Box className={classes.dragDropContainer}>
         <DragDropContainer targetKey="unit"
                            noDragging={notAvailable || !enabled}
-                           onDragStart={() => onUnitClick(unitId, unitName)}
+                           onDragStart={() => onUnitClick(unitId, availableUnit.id, image, unitName)}
                            dragData={{
                              unitId: unitId, availableUnitId: availableUnit.id, unitName: unitName, unitDisplayName: label,
                              image: image, pop: availableUnit.pop, man: availableUnit.man, mun: availableUnit.mun, fuel: availableUnit.fuel

--- a/app/javascript/features/companies/manage/AvailableUnitDroppable.jsx
+++ b/app/javascript/features/companies/manage/AvailableUnitDroppable.jsx
@@ -64,8 +64,8 @@ export const AvailableUnitDroppable = ({
                            noDragging={notAvailable || !enabled}
                            onDragStart={() => onUnitClick(unitId, unitName)}
                            dragData={{
-                             unitId: unitId, unitName: unitName, unitDisplayName: label, image: image, pop: availableUnit.pop,
-                             man: availableUnit.man, mun: availableUnit.mun, fuel: availableUnit.fuel
+                             unitId: unitId, availableUnitId: availableUnit.id, unitName: unitName, unitDisplayName: label,
+                             image: image, pop: availableUnit.pop, man: availableUnit.man, mun: availableUnit.mun, fuel: availableUnit.fuel
                            }}>
           <UnitCard unitId={unitId} label={label} image={image} onUnitClick={onUnitClick} disabled={notAvailable} />
         </DragDropContainer>

--- a/app/javascript/features/companies/manage/CompanyGridDropTarget.jsx
+++ b/app/javascript/features/companies/manage/CompanyGridDropTarget.jsx
@@ -55,7 +55,7 @@ export const CompanyGridDropTarget = ({
     console.log(`${dragData.unitName} dropped into target ${gridIndex}`)
     if (Object.keys(dragData).includes("uuid")) {
       // Moved an existing squad into this drop target
-      const { uuid, id, unitId, unitName, pop, man, mun, fuel, image, index, tab } = dragData
+      const { uuid, id, unitId, availableUnitId, unitName, pop, man, mun, fuel, image, index, tab } = dragData
 
       // Remove it from its previous platoon index
       onSquadDestroy(uuid, id, unitId, pop, man, mun, fuel, index, tab)
@@ -64,8 +64,8 @@ export const CompanyGridDropTarget = ({
       onHitCallback({ ...dragData, vet: 0, index: gridIndex, tab: currentTab })
     } else if (dragData.index !== gridIndex) {
       const uuid = nanoid()
-      const newSquad = createSquad(uuid, null, dragData.unitId, dragData.unitName, dragData.unitDisplayName,
-        dragData.pop, dragData.man, dragData.mun, dragData.fuel, dragData.image, gridIndex, currentTab)
+      const newSquad = createSquad(uuid, null, dragData.unitId, dragData.availableUnitId, dragData.unitName,
+        dragData.unitDisplayName, dragData.pop, dragData.man, dragData.mun, dragData.fuel, dragData.image, gridIndex, currentTab)
       onHitCallback(newSquad)
     } else {
       console.log(`skipping onHit for the same index ${gridIndex}`)

--- a/app/javascript/features/companies/manage/CompanyGridDropTarget.jsx
+++ b/app/javascript/features/companies/manage/CompanyGridDropTarget.jsx
@@ -83,8 +83,8 @@ export const CompanyGridDropTarget = ({
     for (const squad of Object.values(squads)) {
       gridPop += parseFloat(squad.pop)
       squadCards.push(<SquadCard key={squad.uuid}
-                                 uuid={squad.uuid} squadId={squad.id} unitId={squad.unitId} unitName={squad.unitName}
-                                 unitDisplayName={squad.unitDisplayName}
+                                 uuid={squad.uuid} squadId={squad.id} unitId={squad.unitId} availableUnitId={squad.availableUnitId}
+                                 unitName={squad.unitName} unitDisplayName={squad.unitDisplayName}
                                  pop={squad.pop} man={squad.man} mun={squad.mun} fuel={squad.fuel} image={squad.image}
                                  index={squad.index} tab={squad.tab} vet={squad.vet}
                                  onUnitClick={onUnitClick} onDestroyClick={onDestroyClick} enabled={enabled} />)

--- a/app/javascript/features/companies/manage/CompanyManager.jsx
+++ b/app/javascript/features/companies/manage/CompanyManager.jsx
@@ -11,7 +11,7 @@ import { ANTI_ARMOUR, ARMOUR, ASSAULT, CORE, INFANTRY, SUPPORT } from "../../../
 import { addUnitCost, fetchCompanyById, removeUnitCost, selectCompanyById } from "../companiesSlice";
 import { selectAllAvailableUnits, selectAvailableUnitsStatus } from "../../units/availableUnitsSlice"
 import { AvailableUnits } from "./available_units/AvailableUnits";
-import { UnitDetails } from "./UnitDetails";
+import { AvailableUnitDetails } from "./AvailableUnitDetails";
 import {
   addSquad, clearCompanyManager, clearNotifySnackbar,
   removeSquad,
@@ -38,6 +38,7 @@ export const CompanyManager = () => {
   const dispatch = useDispatch()
   const [currentTab, setCurrentTab] = useState(defaultTab)
   const [selectedUnitId, setSelectedUnitId] = useState(null)
+  const [selectedAvailableUnitId, setSelectedAvailableUnitId] = useState(null)
   const [selectedUnitImage, setSelectedUnitImage] = useState(null)
   const [selectedUnitName, setSelectedUnitName] = useState(null)
 
@@ -118,19 +119,20 @@ export const CompanyManager = () => {
     setCurrentTab(newTab)
   }
 
-  const onUnitSelect = (unitId, unitImage, unitName) => {
+  const onUnitSelect = (unitId, availableUnitId, unitImage, unitName) => {
     /** Called when a unit is selected. Populates the unit stats box with relevant data
      * TODO if a squad is clicked, should take upgrades into account
      */
     setSelectedUnitId(unitId)
+    setSelectedAvailableUnitId(availableUnitId)
     setSelectedUnitImage(unitImage)
     setSelectedUnitName(unitName)
   }
 
-  const onDropTargetHit = ({ uuid, id, unitId, unitName, pop, man, mun, fuel, image, index, tab, vet }) => {
+  const onDropTargetHit = ({ uuid, id, unitId, availableUnitId, unitName, pop, man, mun, fuel, image, index, tab, vet }) => {
     console.log(`Added ${unitName}, pop ${pop}, costs ${man}MP ${mun}MU ${fuel}FU to category ${tab} position ${index}`)
     dispatch(addUnitCost({ id: company.id, pop, man, mun, fuel }))
-    dispatch(addSquad({ uuid, id, unitId, unitName, pop, man, mun, fuel, image, index, tab, vet }))
+    dispatch(addSquad({ uuid, id, unitId, availableUnitId, unitName, pop, man, mun, fuel, image, index, tab, vet }))
   }
 
   const onSquadDestroy = (uuid, id, unitId, pop, man, mun, fuel, index, tab) => {
@@ -198,7 +200,7 @@ export const CompanyManager = () => {
             {/*TODO maybe populate by type, alphabetically or cost ASC */}
           </Grid>
           <Grid item md={6} xs={12}>
-            <UnitDetails unitId={selectedUnitId} unitImage={selectedUnitImage} />
+            <AvailableUnitDetails unitId={selectedUnitId} availableUnitId={selectedAvailableUnitId} unitImage={selectedUnitImage} />
           </Grid>
         </Grid>
         <Grid item container spacing={2}>

--- a/app/javascript/features/companies/manage/SquadCard.jsx
+++ b/app/javascript/features/companies/manage/SquadCard.jsx
@@ -55,6 +55,7 @@ export const SquadCard = (
     uuid,
     squadId,
     unitId,
+    availableUnitId,
     unitName,
     unitDisplayName,
     vet,
@@ -104,13 +105,14 @@ export const SquadCard = (
       arrow
     >
       <Card className={classes.squadCard}>
-        <DragDropContainer targetKey="unit" onDragStart={() => onUnitClick(unitId, unitName)}
+        <DragDropContainer targetKey="unit" onDragStart={() => onUnitClick(unitId, availableUnitId, image, unitName)}
                            noDragging={!enabled}
                            dragData={
                              {
                                uuid: uuid,
                                id: squadId,
                                unitId: unitId,
+                               availableUnitId: availableUnitId,
                                unitName: unitName,
                                unitDisplayName: unitDisplayName,
                                pop: pop,
@@ -124,7 +126,7 @@ export const SquadCard = (
                            }
         >
           <Box sx={{ p: 1 }} className={classes.squadCardItems}>
-            <UnitCard unitId={unitId} label={unitName} image={image} onUnitClick={onUnitClick} />
+            <UnitCard unitId={unitId} availableUnitId={availableUnitId} label={unitName} image={image} onUnitClick={onUnitClick} />
             {deleteContent}
           </Box>
         </DragDropContainer>

--- a/app/javascript/features/companies/manage/UnitCard.jsx
+++ b/app/javascript/features/companies/manage/UnitCard.jsx
@@ -22,12 +22,12 @@ const useStyles = makeStyles(() => ({
  * @param onUnitClick
  * @param disabled: Flag to show the disabled state for the unit card
  */
-export const UnitCard = ({ unitId, label, image, onUnitClick, disabled }) => {
+export const UnitCard = ({ unitId, availableUnitId, label, image, onUnitClick, disabled }) => {
   const classes = useStyles()
 
   /** TODO onUnitClick needs to be squad aware */
   return (
-    <Card className={`${classes.unitCard} ${disabled ? 'disabled' : ''}`} onClick={() => onUnitClick(unitId, label)}>
+    <Card className={`${classes.unitCard} ${disabled ? 'disabled' : ''}`} onClick={() => onUnitClick(unitId, availableUnitId, image, label)}>
       <CardMedia component="img" height="45" image={image} alt={label} />
     </Card>
   )

--- a/app/javascript/features/units/squad.js
+++ b/app/javascript/features/units/squad.js
@@ -1,5 +1,6 @@
-export const createAvailableUnit = (unitId, unitName, pop, man, mun, fuel, image, index, tab) => ({
+export const createAvailableUnit = (unitId, availableUnitId, unitName, pop, man, mun, fuel, image, index, tab) => ({
   unitId: unitId,
+  availableUnitId: availableUnitId,
   unitName: unitName,
   pop: pop,
   man: man,
@@ -8,10 +9,11 @@ export const createAvailableUnit = (unitId, unitName, pop, man, mun, fuel, image
   image: image,
 })
 
-export const createSquad = (uuid, id, unitId, unitName, unitDisplayName, pop, man, mun, fuel, image, index, tab, vet=0) => ({
+export const createSquad = (uuid, id, unitId, availableUnitId, unitName, unitDisplayName, pop, man, mun, fuel, image, index, tab, vet=0) => ({
   uuid: uuid,
   id: id,
   unitId: unitId,
+  availableUnitId: availableUnitId,
   unitName: unitName,
   unitDisplayName: unitDisplayName,
   pop: pop,

--- a/app/javascript/features/units/squadsSlice.js
+++ b/app/javascript/features/units/squadsSlice.js
@@ -66,7 +66,7 @@ const buildNewSquadTabs = (squads) => {
     const platoon = tabs[squad.tab][squad.index]
     const uuid = nanoid()
     const image = unitImageMapping[squad.unitName]
-    platoon[uuid] = createSquad(uuid, squad.id, squad.unitId, squad.unitName, squad.unitDisplayName, squad.pop, squad.man, squad.mun,
+    platoon[uuid] = createSquad(uuid, squad.id, squad.unitId, squad.availableUnitId, squad.unitName, squad.unitDisplayName, squad.pop, squad.man, squad.mun,
       squad.fuel, image, squad.index, squad.tab, squad.vet)
   })
   return tabs

--- a/app/models/available_unit.rb
+++ b/app/models/available_unit.rb
@@ -3,15 +3,16 @@
 # Table name: available_units
 #
 #  id                                                                                   :bigint           not null, primary key
-#  available(Number of this unit available to purchase for the company)                 :integer
+#  available(Number of this unit available to purchase for the company)                 :integer          default(0), not null
 #  callin_modifier(Calculated base callin modifier of this unit for the company)        :decimal(, )      not null
-#  company_max(Maximum number of the unit a company can hold)                           :integer          not null
+#  company_max(Maximum number of the unit a company can hold)                           :integer          default(0), not null
 #  fuel(Calculated fuel cost of this unit for the company)                              :integer          not null
 #  man(Calculated man cost of this unit for the company)                                :integer          not null
 #  mun(Calculated mun cost of this unit for the company)                                :integer          not null
 #  pop(Calculated pop cost of this unit for the company)                                :decimal(, )      not null
-#  resupply(Per game resupply)                                                          :integer          not null
-#  resupply_max(How much resupply is available from saved up resupplies, <= company ma) :integer          not null
+#  resupply(Per game resupply)                                                          :integer          default(0), not null
+#  resupply_max(How much resupply is available from saved up resupplies, <= company ma) :integer          default(0), not null
+#  type(Type of available unit)                                                         :string           not null
 #  created_at                                                                           :datetime         not null
 #  updated_at                                                                           :datetime         not null
 #  company_id                                                                           :bigint
@@ -19,8 +20,9 @@
 #
 # Indexes
 #
-#  index_available_units_on_company_id  (company_id)
-#  index_available_units_on_unit_id     (unit_id)
+#  index_available_units_on_company_id                       (company_id)
+#  index_available_units_on_company_id_and_unit_id_and_type  (company_id,unit_id,type) UNIQUE
+#  index_available_units_on_unit_id                          (unit_id)
 #
 # Foreign Keys
 #

--- a/app/models/base_available_unit.rb
+++ b/app/models/base_available_unit.rb
@@ -29,53 +29,6 @@
 #  fk_rails_...  (company_id => companies.id)
 #  fk_rails_...  (unit_id => units.id)
 #
-require "rails_helper"
+class BaseAvailableUnit < AvailableUnit
 
-RSpec.describe AvailableUnit, type: :model do
-  let!(:available_unit) { create :available_unit}
-
-  describe 'associations' do
-    it { should belong_to(:company) }
-    it { should belong_to(:unit) }
-    it { should have_many(:squads) }
-  end
-
-  describe 'validations' do
-    it { should validate_presence_of(:company) }
-    it { should validate_presence_of(:unit) }
-    it { should validate_presence_of(:available) }
-    it { should validate_presence_of(:resupply) }
-    it { should validate_presence_of(:resupply_max) }
-    it { should validate_presence_of(:company_max) }
-    it { should validate_presence_of(:pop) }
-    it { should validate_presence_of(:man) }
-    it { should validate_presence_of(:mun) }
-    it { should validate_presence_of(:fuel) }
-    it { should validate_presence_of(:callin_modifier) }
-    it { should validate_numericality_of(:available).is_greater_than_or_equal_to(0) }
-    it { should validate_numericality_of(:resupply).is_greater_than_or_equal_to(0) }
-    it { should validate_numericality_of(:resupply_max).is_greater_than_or_equal_to(0) }
-    it { should validate_numericality_of(:company_max).is_greater_than_or_equal_to(0) }
-    it { should validate_numericality_of(:pop).is_greater_than_or_equal_to(0) }
-    it { should validate_numericality_of(:man).is_greater_than_or_equal_to(0) }
-    it { should validate_numericality_of(:mun).is_greater_than_or_equal_to(0) }
-    it { should validate_numericality_of(:fuel).is_greater_than_or_equal_to(0) }
-    it { should validate_numericality_of(:callin_modifier).is_greater_than_or_equal_to(0) }
-  end
-
-  it "gets the correct unit name" do
-    unit = create :unit, name: "riflemen"
-    au = create :available_unit, unit: unit
-    expect(au.unit_name).to eq("riflemen")
-  end
-  it "gets the correct unit display name" do
-    unit = create :unit, display_name: "Riflemen"
-    au = create :available_unit, unit: unit
-    expect(au.unit_display_name).to eq("Riflemen")
-  end
-  it "gets the correct unit type" do
-    unit = create :infantry
-    au = create :available_unit, unit: unit
-    expect(au.unit_type).to eq("Infantry")
-  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -42,7 +42,7 @@ class Company < ApplicationRecord
   has_many :available_units, dependent: :destroy
   has_many :squads, dependent: :destroy
   has_many :company_unlocks, dependent: :destroy
-  has_many :unlocks, through: :company_unlocks
+  has_many :doctrine_unlocks, through: :company_unlocks
   has_many :company_offmaps, dependent: :destroy
   has_many :offmaps, through: :company_offmaps
   has_many :company_resource_bonuses, dependent: :destroy

--- a/app/models/company_unlock.rb
+++ b/app/models/company_unlock.rb
@@ -2,23 +2,33 @@
 #
 # Table name: company_unlocks
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  company_id :bigint
-#  unlock_id  :bigint
+#  id                 :bigint           not null, primary key
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  company_id         :bigint
+#  doctrine_unlock_id :bigint
 #
 # Indexes
 #
-#  index_company_unlocks_on_company_id  (company_id)
-#  index_company_unlocks_on_unlock_id   (unlock_id)
+#  index_company_unlocks_on_company_id          (company_id)
+#  index_company_unlocks_on_doctrine_unlock_id  (doctrine_unlock_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (company_id => companies.id)
-#  fk_rails_...  (unlock_id => unlocks.id)
+#  fk_rails_...  (doctrine_unlock_id => doctrine_unlocks.id)
 #
 class CompanyUnlock < ApplicationRecord
   belongs_to :company
-  belongs_to :unlock
+  belongs_to :doctrine_unlock
+
+  def entity
+    Entity.new(self)
+  end
+
+  class Entity < Grape::Entity
+    expose :id
+    expose :company_id, as: :companyId
+    expose :doctrine_unlock, using: DoctrineUnlock::Entity
+  end
 end

--- a/app/models/disabled_unit.rb
+++ b/app/models/disabled_unit.rb
@@ -38,11 +38,11 @@
 #  fk_rails_...  (unit_id => units.id)
 #
 class DisabledUnit < RestrictionUnit
-  before_save :generate_description
+  before_save :generate_internal_description
 
   private
 
-  def generate_description
-    self.description = "#{restriction.name} - #{unit.display_name} - DISABLED"
+  def generate_internal_description
+    self.internal_description = "#{restriction.name} - #{unit.display_name} - DISABLED"
   end
 end

--- a/app/models/disabled_upgrade.rb
+++ b/app/models/disabled_upgrade.rb
@@ -2,20 +2,20 @@
 #
 # Table name: restriction_upgrades
 #
-#  id                                                    :bigint           not null, primary key
-#  description(What does this RestrictionUpgrade do?)    :string
-#  fuel(Fuel cost)                                       :integer
-#  man(Manpower cost)                                    :integer
-#  mun(Munition cost)                                    :integer
-#  pop(Population cost)                                  :integer
-#  priority(Priority of this restriction)                :integer
-#  type(What effect this restriction has on the upgrade) :string           not null
-#  uses(Number of uses this upgrade provides)            :integer
-#  created_at                                            :datetime         not null
-#  updated_at                                            :datetime         not null
-#  restriction_id                                        :bigint
-#  ruleset_id                                            :bigint
-#  upgrade_id                                            :bigint
+#  id                                                          :bigint           not null, primary key
+#  fuel(Fuel cost)                                             :integer
+#  internal_description(What does this RestrictionUpgrade do?) :string
+#  man(Manpower cost)                                          :integer
+#  mun(Munition cost)                                          :integer
+#  pop(Population cost)                                        :integer
+#  priority(Priority of this restriction)                      :integer
+#  type(What effect this restriction has on the upgrade)       :string           not null
+#  uses(Number of uses this upgrade provides)                  :integer
+#  created_at                                                  :datetime         not null
+#  updated_at                                                  :datetime         not null
+#  restriction_id                                              :bigint
+#  ruleset_id                                                  :bigint
+#  upgrade_id                                                  :bigint
 #
 # Indexes
 #
@@ -30,11 +30,11 @@
 #  fk_rails_...  (upgrade_id => upgrades.id)
 #
 class DisabledUpgrade < RestrictionUpgrade
-  before_save :generate_description
+  before_save :generate_internal_description
 
   private
 
-  def generate_description
-    self.description = "#{restriction.name} - #{upgrade.display_name} - DISABLED"
+  def generate_internal_description
+    self.internal_description = "#{restriction.name} - #{upgrade.display_name} - DISABLED"
   end
 end

--- a/app/models/doctrine.rb
+++ b/app/models/doctrine.rb
@@ -27,7 +27,7 @@ class Doctrine < ApplicationRecord
   belongs_to :faction, inverse_of: :doctrines
   has_many :doctrine_unlocks
   has_many :unlocks, through: :doctrine_unlocks
-  has_many :restrictions
+  has_one :restriction
 
   validates_presence_of :name
   validates_presence_of :const_name

--- a/app/models/doctrine_unlock.rb
+++ b/app/models/doctrine_unlock.rb
@@ -33,6 +33,8 @@ class DoctrineUnlock < ApplicationRecord
   has_many :restriction_upgrades, through: :restriction
   has_many :restriction_offmaps, through: :restriction
 
+  before_save :generate_internal_description
+
   def entity
     Entity.new(self)
   end
@@ -46,5 +48,11 @@ class DoctrineUnlock < ApplicationRecord
     expose :branch
     expose :row
     expose :unlock, using: Unlock::Entity
+  end
+
+  private
+
+  def generate_internal_description
+    self.internal_description = "#{doctrine.display_name} | #{unlock.display_name}"
   end
 end

--- a/app/models/doctrine_unlock.rb
+++ b/app/models/doctrine_unlock.rb
@@ -29,9 +29,9 @@ class DoctrineUnlock < ApplicationRecord
   belongs_to :unlock
   has_one :restriction
 
-  has_many :restriction_units
-  has_many :restriction_upgrades
-  has_many :restriction_offmaps
+  has_many :restriction_units, through: :restriction
+  has_many :restriction_upgrades, through: :restriction
+  has_many :restriction_offmaps, through: :restriction
 
   def entity
     Entity.new(self)

--- a/app/models/enabled_unit.rb
+++ b/app/models/enabled_unit.rb
@@ -47,11 +47,11 @@ class EnabledUnit < RestrictionUnit
   validates_numericality_of :resupply_max
   validates_numericality_of :company_max
 
-  before_save :generate_description
+  before_save :generate_internal_description
 
   private
 
-  def generate_description
-    self.description = "#{restriction.name} - #{unit.display_name}"
+  def generate_internal_description
+    self.internal_description = "#{restriction.name} - #{unit.display_name}"
   end
 end

--- a/app/models/enabled_upgrade.rb
+++ b/app/models/enabled_upgrade.rb
@@ -2,20 +2,20 @@
 #
 # Table name: restriction_upgrades
 #
-#  id                                                    :bigint           not null, primary key
-#  description(What does this RestrictionUpgrade do?)    :string
-#  fuel(Fuel cost)                                       :integer
-#  man(Manpower cost)                                    :integer
-#  mun(Munition cost)                                    :integer
-#  pop(Population cost)                                  :integer
-#  priority(Priority of this restriction)                :integer
-#  type(What effect this restriction has on the upgrade) :string           not null
-#  uses(Number of uses this upgrade provides)            :integer
-#  created_at                                            :datetime         not null
-#  updated_at                                            :datetime         not null
-#  restriction_id                                        :bigint
-#  ruleset_id                                            :bigint
-#  upgrade_id                                            :bigint
+#  id                                                          :bigint           not null, primary key
+#  fuel(Fuel cost)                                             :integer
+#  internal_description(What does this RestrictionUpgrade do?) :string
+#  man(Manpower cost)                                          :integer
+#  mun(Munition cost)                                          :integer
+#  pop(Population cost)                                        :integer
+#  priority(Priority of this restriction)                      :integer
+#  type(What effect this restriction has on the upgrade)       :string           not null
+#  uses(Number of uses this upgrade provides)                  :integer
+#  created_at                                                  :datetime         not null
+#  updated_at                                                  :datetime         not null
+#  restriction_id                                              :bigint
+#  ruleset_id                                                  :bigint
+#  upgrade_id                                                  :bigint
 #
 # Indexes
 #
@@ -36,11 +36,11 @@ class EnabledUpgrade < RestrictionUpgrade
   validates_numericality_of :pop
   validates_numericality_of :uses
 
-  before_save :generate_description
+  before_save :generate_internal_description
 
   private
 
-  def generate_description
-    self.description = "#{restriction.name} - #{upgrade.display_name}"
+  def generate_internal_description
+    self.internal_description = "#{restriction.name} - #{upgrade.display_name}"
   end
 end

--- a/app/models/faction.rb
+++ b/app/models/faction.rb
@@ -18,7 +18,7 @@
 #
 class Faction < ApplicationRecord
   has_many :doctrines, inverse_of: :faction
-  has_many :restrictions
+  has_one :restriction
 
   enum side: {
     allied: "allied",

--- a/app/models/restriction.rb
+++ b/app/models/restriction.rb
@@ -15,6 +15,7 @@
 #
 # Indexes
 #
+#  idx_restrictions_uniq_id                  (faction_id,doctrine_id,doctrine_unlock_id,unlock_id) UNIQUE
 #  index_restrictions_on_doctrine_id         (doctrine_id)
 #  index_restrictions_on_doctrine_unlock_id  (doctrine_unlock_id)
 #  index_restrictions_on_faction_id          (faction_id)

--- a/app/models/restriction_upgrade.rb
+++ b/app/models/restriction_upgrade.rb
@@ -2,19 +2,20 @@
 #
 # Table name: restriction_upgrades
 #
-#  id                                                    :bigint           not null, primary key
-#  fuel(Fuel cost)                                       :integer
-#  man(Manpower cost)                                    :integer
-#  mun(Munition cost)                                    :integer
-#  pop(Population cost)                                  :integer
-#  priority(Priority of this restriction)                :integer
-#  type(What effect this restriction has on the upgrade) :string           not null
-#  uses(Number of uses this upgrade provides)            :integer
-#  created_at                                            :datetime         not null
-#  updated_at                                            :datetime         not null
-#  restriction_id                                        :bigint
-#  ruleset_id                                            :bigint
-#  upgrade_id                                            :bigint
+#  id                                                          :bigint           not null, primary key
+#  fuel(Fuel cost)                                             :integer
+#  internal_description(What does this RestrictionUpgrade do?) :string
+#  man(Manpower cost)                                          :integer
+#  mun(Munition cost)                                          :integer
+#  pop(Population cost)                                        :integer
+#  priority(Priority of this restriction)                      :integer
+#  type(What effect this restriction has on the upgrade)       :string           not null
+#  uses(Number of uses this upgrade provides)                  :integer
+#  created_at                                                  :datetime         not null
+#  updated_at                                                  :datetime         not null
+#  restriction_id                                              :bigint
+#  ruleset_id                                                  :bigint
+#  upgrade_id                                                  :bigint
 #
 # Indexes
 #

--- a/app/models/squad.rb
+++ b/app/models/squad.rb
@@ -86,6 +86,7 @@ class Squad < ApplicationRecord
     expose :category_position, as: :index
     expose :company_id, as: :companyId
     expose :unit_id, as: :unitId
+    expose :available_unit_id, as: :availableUnitId
     expose :unit_name, as: :unitName
     expose :unit_display_name, as: :unitDisplayName
     expose :pop

--- a/app/models/unit_swap.rb
+++ b/app/models/unit_swap.rb
@@ -12,9 +12,10 @@
 #
 # Indexes
 #
-#  index_unit_swaps_on_new_unit_id  (new_unit_id)
-#  index_unit_swaps_on_old_unit_id  (old_unit_id)
-#  index_unit_swaps_on_unlock_id    (unlock_id)
+#  index_unit_swaps_on_new_unit_id                (new_unit_id)
+#  index_unit_swaps_on_old_unit_id                (old_unit_id)
+#  index_unit_swaps_on_unlock_id                  (unlock_id)
+#  index_unit_swaps_on_unlock_id_and_old_unit_id  (unlock_id,old_unit_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/unit_swap.rb
+++ b/app/models/unit_swap.rb
@@ -2,13 +2,13 @@
 #
 # Table name: unit_swaps
 #
-#  id                                        :bigint           not null, primary key
-#  description(Description of this UnitSwap) :string
-#  created_at                                :datetime         not null
-#  updated_at                                :datetime         not null
-#  new_unit_id                               :bigint           not null
-#  old_unit_id                               :bigint           not null
-#  unlock_id                                 :bigint           not null
+#  id                                                          :bigint           not null, primary key
+#  internal_description(Internal description of this UnitSwap) :string
+#  created_at                                                  :datetime         not null
+#  updated_at                                                  :datetime         not null
+#  new_unit_id                                                 :bigint           not null
+#  old_unit_id                                                 :bigint           not null
+#  unlock_id                                                   :bigint           not null
 #
 # Indexes
 #
@@ -28,11 +28,11 @@ class UnitSwap < ApplicationRecord
   belongs_to :old_unit, class_name: "Unit"
   belongs_to :new_unit, class_name: "Unit"
 
-  before_save :generate_description
+  before_save :generate_internal_description
 
   private
 
-  def generate_description
-    self.description = "#{unlock.display_name} | #{old_unit.display_name} -> #{new_unit.display_name}"
+  def generate_internal_description
+    self.internal_description = "#{unlock.display_name} | #{old_unit.display_name} -> #{new_unit.display_name}"
   end
 end

--- a/app/models/unlock.rb
+++ b/app/models/unlock.rb
@@ -20,9 +20,9 @@ class Unlock < ApplicationRecord
   has_many :doctrines, through: :doctrine_unlocks
   has_one :restriction
 
-  has_many :restriction_units
-  has_many :restriction_upgrades
-  has_many :restriction_offmaps
+  has_many :restriction_units, through: :restriction
+  has_many :restriction_upgrades, through: :restriction
+  has_many :restriction_offmaps, through: :restriction
 
   validates_presence_of :name
   validates_presence_of :display_name

--- a/app/services/available_units_service.rb
+++ b/app/services/available_units_service.rb
@@ -18,6 +18,8 @@ class AvailableUnitsService
   #
   #   ** Ignores existing available units for now **
   def build_new_company_available_units
+    validate_empty_available_units
+
     # Get restriction for Faction, then find all faction allowed units
     faction_restriction = Restriction.find_by(faction: @faction)
     faction_allowed_units = get_enabled_unit_hash faction_restriction
@@ -35,7 +37,23 @@ class AvailableUnitsService
     allowed_units_hashes = merge_allowed_units(allowed_units_hashes, doctrine_allowed_units)
     allowed_units_hashes = remove_disabled_units(allowed_units_hashes, doctrine_disabled_units)
 
-    create_available_units(allowed_units_hashes)
+    # Create available units with the filtered collection of restriction units
+    create_base_available_units(allowed_units_hashes.values)
+  end
+
+  # When creating new base_available_units, start available at max resupply value
+  def create_base_available_units(restriction_units)
+    available_units = restriction_units.map do |unit_data|
+      instantiate_base_available_unit(unit_data)
+    end
+    AvailableUnit.import!(available_units)
+  end
+
+  # Given units to remove, remove all available_units (all types) from the company associated
+  # with those units. Destroy squads using those available units.
+  def remove_available_units(units_to_remove)
+    available_units = AvailableUnit.where(company: @company, unit: units_to_remove)
+    available_units.destroy_all # squads destroyed via dependent destroy
   end
 
   private
@@ -63,19 +81,12 @@ class AvailableUnitsService
     existing_units_hash
   end
 
-  # When creating new available_units, start available at max resupply value
-  def create_available_units(unit_hashes)
-    validate_empty_available_units
-
-    available_units = []
-    unit_hashes.values.map do |unit_data|
-      available_units << AvailableUnit.new(unit: unit_data.unit, company: @company, available: unit_data.resupply_max,
-                                           resupply: unit_data.resupply, resupply_max: unit_data.resupply_max,
-                                           company_max: unit_data.company_max, pop: unit_data.pop,
-                                           man: unit_data.man, mun: unit_data.mun, fuel: unit_data.fuel,
-                                           callin_modifier: unit_data.callin_modifier)
-    end
-    AvailableUnit.import!(available_units)
+  def instantiate_base_available_unit(restriction_unit)
+    BaseAvailableUnit.new(unit: restriction_unit.unit, company: @company, available: restriction_unit.resupply_max,
+                          resupply: restriction_unit.resupply, resupply_max: restriction_unit.resupply_max,
+                          company_max: restriction_unit.company_max, pop: restriction_unit.pop,
+                          man: restriction_unit.man, mun: restriction_unit.mun, fuel: restriction_unit.fuel,
+                          callin_modifier: restriction_unit.callin_modifier)
   end
 
   def validate_empty_available_units

--- a/app/services/company_service.rb
+++ b/app/services/company_service.rb
@@ -176,7 +176,7 @@ class CompanyService
     # Build hash of tab and index to pop
     platoon_pop_by_tab_and_index = build_empty_tab_index_pop
 
-    squads = company.squads.map { |s| { unit_id: s.unit.id, tab: s.tab_category, index: s.category_position, available_unit_id: s.available_unit_id } }
+    squads = company.squads.map { |s| { tab: s.tab_category, index: s.category_position, available_unit_id: s.available_unit_id } }
 
     # Calculate resources used by the input squads
     man_new, mun_new, fuel_new, pop_new = calculate_squad_resources(squads, available_units_by_id, platoon_pop_by_tab_and_index)

--- a/app/services/company_service.rb
+++ b/app/services/company_service.rb
@@ -79,21 +79,24 @@ class CompanyService
     validate_squad_units_exist(uniq_unit_ids_new, uniq_units_new_by_id)
 
     # Get available units for the company - cost is stored there
-    # NOTE: Not handling free units for now, likely will need a flag on AvailableUnit
     available_units = company.available_units
+
+    # Get unique squad available_unit_ids
+    uniq_available_unit_ids_new = squads.map { |s| s[:available_unit_id] }.uniq
+    # Validate that all available_unit_ids correspond to existing available_units
+    validate_squad_available_units_exist(uniq_available_unit_ids_new, available_units, company.id)
 
     # Validates that all unit ids correspond to available units
     validate_squad_units_available(uniq_unit_ids_new, available_units, company.id)
 
-    # For now, expect unit id and company id are a unique constraint for AvailableUnits so using simple index_by,
-    # but may change in the future to support free units
-    available_units_by_unit_id = available_units.index_by(&:unit_id)
+    # Index available_units by id
+    available_units_by_id = available_units.index_by(&:id)
 
     # Build hash of tab and index to pop
     platoon_pop_by_tab_and_index = build_empty_tab_index_pop
 
     # Calculate resources used by the input squads
-    man_new, mun_new, fuel_new, pop_new = calculate_squad_resources(squads, available_units_by_unit_id, platoon_pop_by_tab_and_index)
+    man_new, mun_new, fuel_new, pop_new = calculate_squad_resources(squads, available_units_by_id, platoon_pop_by_tab_and_index)
 
     # Calculate resources remaining when subtracting the squad resources from the company's total starting resources
     # Raise validation error if the new squads' cost is greater in one or more resource than the company's total starting resources
@@ -104,19 +107,19 @@ class CompanyService
     validate_platoon_pop(platoon_pop_by_tab_and_index)
 
     ## Get all existing squads for the company
-    existing_squads_by_unit_id = existing_squads.group_by(&:unit_id)
+    existing_squads_by_available_unit_id = existing_squads.group_by(&:available_unit_id)
 
-    # Get payload squads by unit id
-    payload_squads_by_unit_id = squads.group_by { |s| s[:unit_id] }
+    # Get payload squads by available unit id
+    payload_squads_by_available_unit_id = squads.group_by { |s| s[:available_unit_id] }
 
     ## Calculate delta in number of each unit against the available number of that unit for the company
     ## Raise validation error if insufficient
-    available_changes = build_available_unit_deltas(company, payload_squads_by_unit_id, existing_squads_by_unit_id, available_units_by_unit_id)
+    available_changes = build_available_unit_deltas(company, payload_squads_by_available_unit_id, existing_squads_by_available_unit_id, available_units_by_id)
 
     # Check for any existing squads that have units which aren't in the payload squads list. These represent squads we
     # will be destroying and units that will give their availability back as the unit is not included at all in the new
     # squads list
-    add_existing_squads_to_remove(existing_squads_by_unit_id, available_changes)
+    add_existing_squads_to_remove(existing_squads_by_available_unit_id, available_changes)
 
     ##### At this point, we know the company can have the new squads as they are within price and availability
 
@@ -127,7 +130,7 @@ class CompanyService
       squads.each do |s|
         if s[:squad_id].blank?
           ## Create new Squad records for squads without squad id
-          available_unit = available_units_by_unit_id[s[:unit_id]]
+          available_unit = available_units_by_id[s[:available_unit_id]]
           new_squads << Squad.new(company: company, vet: s[:vet], tab_category: s[:tab],
                                   category_position: s[:index], available_unit: available_unit)
         else
@@ -143,8 +146,8 @@ class CompanyService
       Squad.where(id: [squad_ids_to_delete]).destroy_all if squad_ids_to_delete.present?
 
       ## Update unit available number for every squad operation above
-      available_changes.each do |unit_id, delta|
-        available_unit = available_units_by_unit_id[unit_id]
+      available_changes.each do |available_unit_id, delta|
+        available_unit = available_units_by_id[available_unit_id]
         new_available_number = available_unit.available + delta
         available_unit.update!(available: [new_available_number, 0].max)
       end
@@ -167,17 +170,16 @@ class CompanyService
   # Based on squads of the company and ruleset starting resources, determine what resources are left
   # TODO refactor with similar block in #update_company_squads
   def recalculate_resources(company)
-    # For now, expect unit id and company id are a unique constraint for AvailableUnits so using simple index_by,
-    # but may change in the future to support free units
-    available_units_by_unit_id = company.available_units.index_by(&:unit_id)
+    # Index available units by id
+    available_units_by_id = company.available_units.index_by(&:id)
 
     # Build hash of tab and index to pop
     platoon_pop_by_tab_and_index = build_empty_tab_index_pop
 
-    squads = company.squads.map { |s| { unit_id: s.unit.id, tab: s.tab_category, index: s.category_position } }
+    squads = company.squads.map { |s| { unit_id: s.unit.id, tab: s.tab_category, index: s.category_position, available_unit_id: s.available_unit_id } }
 
     # Calculate resources used by the input squads
-    man_new, mun_new, fuel_new, pop_new = calculate_squad_resources(squads, available_units_by_unit_id, platoon_pop_by_tab_and_index)
+    man_new, mun_new, fuel_new, pop_new = calculate_squad_resources(squads, available_units_by_id, platoon_pop_by_tab_and_index)
 
     # Calculate resources remaining when subtracting the squad resources from the company's total starting resources
     # Raise validation error if the new squads' cost is greater in one or more resource than the company's total starting resources
@@ -224,6 +226,13 @@ class CompanyService
     end
   end
 
+  def validate_squad_available_units_exist(uniq_available_unit_ids_new, available_units, company_id)
+    diff = uniq_available_unit_ids_new - available_units.pluck(:id).uniq
+    unless diff.empty?
+      raise CompanyUpdateValidationError.new("Invalid available_unit_id(s) given in company #{company_id} squad update: #{diff}")
+    end
+  end
+
   # Validates that all unit ids correspond to available units
   def validate_squad_units_available(uniq_unit_ids_new, available_units, company_id)
     uniq_available_unit_ids = available_units.pluck(:unit_id).uniq
@@ -249,7 +258,7 @@ class CompanyService
   # Calculates manpower, munitions, fuel, and pop used by the input squads, based on costs of the corresponding
   # AvailableUnit for the squad's unit id. Also increments the pop of the platoon_pop_by_tab_and_index value for the
   # tab and index the squad is in.
-  def calculate_squad_resources(squads, available_units_by_unit_id, platoon_pop_by_tab_and_index)
+  def calculate_squad_resources(squads, available_units_by_id, platoon_pop_by_tab_and_index)
     # TODO include upgrade prices
     # TODO include resource bonuses
     man_new = 0
@@ -258,7 +267,7 @@ class CompanyService
     pop_new = 0
 
     squads.each do |squad|
-      available_unit = available_units_by_unit_id[squad[:unit_id]]
+      available_unit = available_units_by_id[squad[:available_unit_id]]
       man_new += available_unit.man
       mun_new += available_unit.mun
       fuel_new += available_unit.fuel
@@ -312,32 +321,32 @@ class CompanyService
   # Calculate delta in number of each unit against the available number of that unit for the company
   # Take into account the difference between the existing number of squads of that unit and the number of squads of that unit in the payload
   # Raise validation error if insufficient
-  def build_available_unit_deltas(company, payload_squads_by_unit_id, existing_squads_by_unit_id, available_units_by_unit_id)
+  def build_available_unit_deltas(company, payload_squads_by_available_unit_id, existing_squads_by_available_unit_id, available_units_by_id)
     available_changes = {}
-    payload_squads_by_unit_id.each do |unit_id, payload_unit_squads|
-      if existing_squads_by_unit_id.include? unit_id
-        existing_count = existing_squads_by_unit_id[unit_id].size
+    payload_squads_by_available_unit_id.each do |available_unit_id, payload_unit_squads|
+      if existing_squads_by_available_unit_id.include? available_unit_id
+        existing_count = existing_squads_by_available_unit_id[available_unit_id].size
       else
         existing_count = 0
       end
       payload_unit_count = payload_unit_squads.size
       availability_delta = existing_count - payload_unit_count
-      available_number = available_units_by_unit_id[unit_id].available
+      available_number = available_units_by_id[available_unit_id].available
 
-      # Inverse of the availability delta as the availablity delta is how much we are changing down the available number
-      # so the inverse is how much net the available number must compare aagainst
+      # Inverse of the availability delta as the availability delta is how much we are changing down the available number
+      # so the inverse is how much net the available number must compare against
       # Ex, 0 existing, 2 payload count, 2 available, then the availability delta is -2 as we are going to adjust down available by 2.
       #   To validate, we take the inverse (2), and compare against the available number as that 2 is what we are net adding to the company for the unit
       # Ex, 2 existing, 1 payload count, 0 available, then the availability delta is 1 as we are adjusting up by 1, as we are making 1 more available
       #   To validate we take the inverse, -1, and compare against the available number. For cases like this where the payload count is < existing, we should
       #   always pass the validation as we are adding to the available number for the unit
       unless -availability_delta <= available_number
-        raise CompanyUpdateValidationError.new("Insufficient availability to create squads for unit #{unit_id} in company"\
+        raise CompanyUpdateValidationError.new("Insufficient availability to create squads for available unit #{available_unit_id} in company"\
           " #{company.id}: Existing count #{existing_count}, payload count #{payload_unit_count}, available number #{available_number}")
       end
 
       # Save the delta so we can update it later after we finish validating availability
-      available_changes[unit_id] = availability_delta
+      available_changes[available_unit_id] = availability_delta
     end
     available_changes
   end
@@ -345,11 +354,11 @@ class CompanyService
   # Check for any existing squads that have units which aren't in the payload squads list. These represent squads we
   # will be destroying and units that will give their availability back as the unit is not included at all in the new
   # squads list
-  def add_existing_squads_to_remove(existing_squads_by_unit_id, available_changes)
-    existing_squads_by_unit_id.each do |unit_id, existing_unit_squads|
-      next if available_changes.include? unit_id
+  def add_existing_squads_to_remove(existing_squads_by_available_unit_id, available_changes)
+    existing_squads_by_available_unit_id.each do |available_unit_id, existing_unit_squads|
+      next if available_changes.include? available_unit_id
 
-      available_changes[unit_id] = existing_unit_squads.size
+      available_changes[available_unit_id] = existing_unit_squads.size
     end
   end
 end

--- a/app/services/company_unlock_service.rb
+++ b/app/services/company_unlock_service.rb
@@ -50,7 +50,7 @@ class CompanyUnlockService
       # Recalculate company resources when squads might be changed
       if disabled_units.present? || unit_swaps.present?
         company_service = CompanyService.new(nil)
-        company_service.recalculate_resources(@company)
+        company_service.recalculate_resources(@company.reload)
       end
 
       # Create a CompanyUnlock and reduce company vps

--- a/app/services/company_unlock_service.rb
+++ b/app/services/company_unlock_service.rb
@@ -1,0 +1,120 @@
+class CompanyUnlockService
+  class CompanyUnlockValidationError < StandardError; end
+
+  def initialize(company)
+    @company = company
+  end
+
+  def purchase_doctrine_unlock(doctrine_unlock)
+    unlock = doctrine_unlock.unlock
+
+    # Validate company's doctrine matches doctrine unlock's doctrine
+    validate_correct_doctrine(doctrine_unlock)
+    # Validate company has enough vps to pay the vp cost
+    validate_sufficient_vps(doctrine_unlock)
+    # Validate company does not already have the doctrine unlock
+    validate_unpurchased(doctrine_unlock)
+
+    squads = Squad.includes(available_unit: :unit).where(company: @company)
+
+    # Get Restrictions for the doctrineUnlock and associated unlock
+    du_restriction = doctrine_unlock.restriction
+    u_restriction = unlock.restriction
+
+    # Get EnabledUnits for those restrictions
+    enabled_units = EnabledUnit.includes(:unit).where(restriction: [du_restriction, u_restriction])
+
+    # Get DisabledUnits for those restrictions
+    disabled_units = DisabledUnit.includes(:unit).where(restriction: [du_restriction, u_restriction])
+    # Get Units for the disabled_units
+    units_to_remove = disabled_units.map { |du| du.unit }
+
+    # Get UnitSwaps for the unlock
+    unit_swaps = UnitSwap.includes(:old_unit, :new_unit).where(unlock: unlock)
+
+    # TODO other RestrictionUnit cases
+
+    available_units_service = AvailableUnitsService.new(@company)
+
+    ActiveRecord::Base.transaction do
+      # Add available_units for units to add
+      available_units_service.create_base_available_units(enabled_units) unless enabled_units.blank?
+
+      # Perform any unit swaps
+      swap_squad_units(squads, unit_swaps) unless unit_swaps.blank?
+
+      # Destroy available_units of disabled units
+      # Destroy squads containing units to disable that weren't swapped
+      available_units_service.remove_available_units(units_to_remove) unless units_to_remove.blank?
+
+      # Recalculate company resources when squads might be changed
+      if disabled_units.present? || unit_swaps.present?
+        company_service = CompanyService.new(nil)
+        company_service.recalculate_resources(@company)
+      end
+
+      # Create a CompanyUnlock and reduce company vps
+      pay_for_company_unlock(doctrine_unlock)
+    end
+  end
+
+  private
+
+  # For the given squads, determines if the squad's unit is in the list of units to swap.
+  # If so, replaces the squad's available_unit with that of the replacement unit
+  # Adjusts down the replacement available_unit.available by 1 for each squad swapped
+  #
+  # NOTE: Does not look at upgrades purchased for the Squad previously.
+  def swap_squad_units(squads, unit_swaps)
+    old_unit_to_unit_swap = unit_swaps.index_by(&:old_unit) # Unit swap is uniquely indexed on [unlock, old_unit]
+    old_units = old_unit_to_unit_swap.keys
+
+    # Query for the company's base_available_unit as a unit swap does not necessarily need to be tied to enabling/disabling units
+    unit_id_to_available_unit = BaseAvailableUnit.where(company: @company).index_by(&:unit_id)
+
+    squads.each do |squad|
+      if old_units.include? squad.unit
+        # Found a squad with an old unit, replace with new unit
+        Rails.logger.info("Found old unit #{squad.unit} in squad #{squad.id}")
+        unit_swap = old_unit_to_unit_swap[squad.unit]
+        au = unit_id_to_available_unit[unit_swap.new_unit_id]
+
+        if au.blank?
+          Rails.logger.info("AvailableUnit for new unit id #{unit_swap.new_unit_id} does not exist for the company, skipping swap")
+          next
+        end
+
+        squad.update!(available_unit: au)
+        new_available = [au.available - 1, 0].max
+        au.update!(available: new_available)
+      end
+    end
+  end
+
+  # Already validated VPs available and not duplicative company_unlock
+  def pay_for_company_unlock(doctrine_unlock)
+    CompanyUnlock.create!(company: @company, doctrine_unlock: doctrine_unlock)
+    new_vps = @company.vps_current - doctrine_unlock.vp_cost
+    @company.update!(vps_current: new_vps)
+  end
+
+  def validate_correct_doctrine(doctrine_unlock)
+    if @company.doctrine.name != doctrine_unlock.doctrine.name
+      raise CompanyUnlockValidationError.new("Company #{@company.id} has doctrine #{@company.doctrine.name} but doctrine unlock #{doctrine_unlock.id} "\
+        "belongs to doctrine #{doctrine_unlock.doctrine.name}")
+    end
+  end
+
+  def validate_sufficient_vps(doctrine_unlock)
+    if @company.vps_current < doctrine_unlock.vp_cost
+      raise CompanyUnlockValidationError.new("Company #{@company.id} has insufficient VPs to purchase doctrine unlock #{doctrine_unlock.id}, have "\
+        "#{@company.vps_current} need #{doctrine_unlock.vp_cost}")
+    end
+  end
+
+  def validate_unpurchased(doctrine_unlock)
+    if @company.company_unlocks.exists?(doctrine_unlock: doctrine_unlock)
+      raise CompanyUnlockValidationError.new("Company #{@company.id} already owns doctrine unlock #{doctrine_unlock.id}")
+    end
+  end
+end

--- a/db/migrate/20211114220437_create_doctrine_unlocks.rb
+++ b/db/migrate/20211114220437_create_doctrine_unlocks.rb
@@ -3,6 +3,7 @@ class CreateDoctrineUnlocks < ActiveRecord::Migration[6.1]
     create_table :doctrine_unlocks, comment: "Associates doctrines to unlocks" do |t|
       t.references :doctrine, index: true, foreign_key: true
       t.references :unlock, index: true, foreign_key: true
+      t.integer :vp_cost, default: 0, null: false, comment: "VP cost of this doctrine unlock"
       t.integer :tree, comment: "Which tree of the doctrine this unlock will appear at"
       t.integer :branch, comment: "Which branch of the doctrine tree this unlock will appear at"
       t.integer :row, comment: "Which row of the doctrine tree branch this unlock will appear at"

--- a/db/migrate/20211114220437_create_doctrine_unlocks.rb
+++ b/db/migrate/20211114220437_create_doctrine_unlocks.rb
@@ -3,6 +3,7 @@ class CreateDoctrineUnlocks < ActiveRecord::Migration[6.1]
     create_table :doctrine_unlocks, comment: "Associates doctrines to unlocks" do |t|
       t.references :doctrine, index: true, foreign_key: true
       t.references :unlock, index: true, foreign_key: true
+      t.string :internal_description, comment: "Doctrine and Unlock names"
       t.integer :vp_cost, default: 0, null: false, comment: "VP cost of this doctrine unlock"
       t.integer :tree, comment: "Which tree of the doctrine this unlock will appear at"
       t.integer :branch, comment: "Which branch of the doctrine tree this unlock will appear at"

--- a/db/migrate/20211114222545_create_restrictions.rb
+++ b/db/migrate/20211114222545_create_restrictions.rb
@@ -11,5 +11,7 @@ class CreateRestrictions < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+
+    add_index :restrictions, [:faction_id, :doctrine_id, :doctrine_unlock_id, :unlock_id], unique: true, name: "idx_restrictions_uniq_id"
   end
 end

--- a/db/migrate/20211120231148_create_company_unlocks.rb
+++ b/db/migrate/20211120231148_create_company_unlocks.rb
@@ -2,7 +2,7 @@ class CreateCompanyUnlocks < ActiveRecord::Migration[6.1]
   def change
     create_table :company_unlocks do |t|
       t.references :company, index: true, foreign_key: true
-      t.references :unlock, index: true, foreign_key: true
+      t.references :doctrine_unlock, index: true, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20211129004739_create_available_units.rb
+++ b/db/migrate/20211129004739_create_available_units.rb
@@ -3,6 +3,7 @@ class CreateAvailableUnits < ActiveRecord::Migration[6.1]
     create_table :available_units, comment: "Unit availability per company" do |t|
       t.references :company, index: true, foreign_key: true
       t.references :unit, index: true, foreign_key: true
+      t.string :type, null: false, comment: "Type of available unit"
       t.integer :available, default: 0, null: false, comment: "Number of this unit available to purchase for the company"
       t.integer :resupply, default: 0, null: false, comment: "Per game resupply"
       t.integer :resupply_max, default: 0, null: false, comment: "How much resupply is available from saved up resupplies, <= company ma"
@@ -16,5 +17,7 @@ class CreateAvailableUnits < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+
+    add_index :available_units, [:company_id, :unit_id, :type], unique: true
   end
 end

--- a/db/migrate/20211129010221_create_restriction_units.rb
+++ b/db/migrate/20211129010221_create_restriction_units.rb
@@ -4,7 +4,7 @@ class CreateRestrictionUnits < ActiveRecord::Migration[6.1]
       t.references :restriction, index: true, foreign_key: true
       t.references :unit, index: true, foreign_key: true
       t.references :ruleset, index: true, foreign_key: true
-      t.string :description, null: false, comment: "What does this RestrictionUnit do?"
+      t.string :internal_description, null: false, comment: "What does this RestrictionUnit do?"
       t.string :type, null: false, comment: "What effect this restriction has on the unit"
       t.decimal :pop, comment: "Population cost"
       t.integer :man, comment: "Manpower cost"

--- a/db/migrate/20230130034149_create_restriction_upgrades.rb
+++ b/db/migrate/20230130034149_create_restriction_upgrades.rb
@@ -4,7 +4,7 @@ class CreateRestrictionUpgrades < ActiveRecord::Migration[6.1]
       t.references :restriction, index: true, foreign_key: true
       t.references :upgrade, index: true, foreign_key: true
       t.references :ruleset, index: true, foreign_key: true
-      t.string :description, comment: "What does this RestrictionUpgrade do?"
+      t.string :internal_description, comment: "What does this RestrictionUpgrade do?"
       t.string :type, null: false, comment: "What effect this restriction has on the upgrade"
       t.integer :uses, comment: "Number of uses this upgrade provides"
       t.integer :pop, comment: "Population cost"

--- a/db/migrate/20230203194040_create_unit_swaps.rb
+++ b/db/migrate/20230203194040_create_unit_swaps.rb
@@ -4,7 +4,7 @@ class CreateUnitSwaps < ActiveRecord::Migration[6.1]
       t.references :unlock, index: true, foreign_key: true, null: false
       t.references :old_unit, null: false, foreign_key: { to_table: :units }
       t.references :new_unit, null: false, foreign_key: { to_table: :units }
-      t.string :description, comment: "Description of this UnitSwap"
+      t.string :internal_description, comment: "Internal description of this UnitSwap"
 
       t.timestamps
     end

--- a/db/migrate/20230203194040_create_unit_swaps.rb
+++ b/db/migrate/20230203194040_create_unit_swaps.rb
@@ -8,5 +8,7 @@ class CreateUnitSwaps < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+
+    add_index :unit_swaps, [:unlock_id, :old_unit_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
   create_table "available_units", comment: "Unit availability per company", force: :cascade do |t|
     t.bigint "company_id"
     t.bigint "unit_id"
+    t.string "type", null: false, comment: "Type of available unit"
     t.integer "available", default: 0, null: false, comment: "Number of this unit available to purchase for the company"
     t.integer "resupply", default: 0, null: false, comment: "Per game resupply"
     t.integer "resupply_max", default: 0, null: false, comment: "How much resupply is available from saved up resupplies, <= company ma"
@@ -57,6 +58,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
     t.decimal "callin_modifier", null: false, comment: "Calculated base callin modifier of this unit for the company"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["company_id", "unit_id", "type"], name: "index_available_units_on_company_id_and_unit_id_and_type", unique: true
     t.index ["company_id"], name: "index_available_units_on_company_id"
     t.index ["unit_id"], name: "index_available_units_on_unit_id"
   end
@@ -164,16 +166,17 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
 
   create_table "company_unlocks", force: :cascade do |t|
     t.bigint "company_id"
-    t.bigint "unlock_id"
+    t.bigint "doctrine_unlock_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["company_id"], name: "index_company_unlocks_on_company_id"
-    t.index ["unlock_id"], name: "index_company_unlocks_on_unlock_id"
+    t.index ["doctrine_unlock_id"], name: "index_company_unlocks_on_doctrine_unlock_id"
   end
 
   create_table "doctrine_unlocks", comment: "Associates doctrines to unlocks", force: :cascade do |t|
     t.bigint "doctrine_id"
     t.bigint "unlock_id"
+    t.integer "vp_cost", default: 0, null: false, comment: "VP cost of this doctrine unlock"
     t.integer "tree", comment: "Which tree of the doctrine this unlock will appear at"
     t.integer "branch", comment: "Which branch of the doctrine tree this unlock will appear at"
     t.integer "row", comment: "Which row of the doctrine tree branch this unlock will appear at"
@@ -325,6 +328,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["doctrine_id"], name: "index_restrictions_on_doctrine_id"
     t.index ["doctrine_unlock_id"], name: "index_restrictions_on_doctrine_unlock_id"
+    t.index ["faction_id", "doctrine_id", "doctrine_unlock_id", "unlock_id"], name: "idx_restrictions_uniq_id", unique: true
     t.index ["faction_id"], name: "index_restrictions_on_faction_id"
     t.index ["unlock_id"], name: "index_restrictions_on_unlock_id"
     t.check_constraint "num_nonnulls(faction_id, doctrine_id, doctrine_unlock_id, unlock_id) = 1", name: "chk_only_one_is_not_null"
@@ -381,6 +385,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["new_unit_id"], name: "index_unit_swaps_on_new_unit_id"
     t.index ["old_unit_id"], name: "index_unit_swaps_on_old_unit_id"
+    t.index ["unlock_id", "old_unit_id"], name: "index_unit_swaps_on_unlock_id_and_old_unit_id", unique: true
     t.index ["unlock_id"], name: "index_unit_swaps_on_unlock_id"
   end
 
@@ -449,7 +454,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
   add_foreign_key "company_resource_bonuses", "companies"
   add_foreign_key "company_resource_bonuses", "resource_bonuses"
   add_foreign_key "company_unlocks", "companies"
-  add_foreign_key "company_unlocks", "unlocks"
+  add_foreign_key "company_unlocks", "doctrine_unlocks"
   add_foreign_key "doctrine_unlocks", "doctrines"
   add_foreign_key "doctrine_unlocks", "unlocks"
   add_foreign_key "doctrines", "factions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -176,6 +176,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
   create_table "doctrine_unlocks", comment: "Associates doctrines to unlocks", force: :cascade do |t|
     t.bigint "doctrine_id"
     t.bigint "unlock_id"
+    t.string "internal_description", comment: "Doctrine and Unlock names"
     t.integer "vp_cost", default: 0, null: false, comment: "VP cost of this doctrine unlock"
     t.integer "tree", comment: "Which tree of the doctrine this unlock will appear at"
     t.integer "branch", comment: "Which branch of the doctrine tree this unlock will appear at"
@@ -274,7 +275,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
     t.bigint "restriction_id"
     t.bigint "unit_id"
     t.bigint "ruleset_id"
-    t.string "description", null: false, comment: "What does this RestrictionUnit do?"
+    t.string "internal_description", null: false, comment: "What does this RestrictionUnit do?"
     t.string "type", null: false, comment: "What effect this restriction has on the unit"
     t.decimal "pop", comment: "Population cost"
     t.integer "man", comment: "Manpower cost"
@@ -301,7 +302,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
     t.bigint "restriction_id"
     t.bigint "upgrade_id"
     t.bigint "ruleset_id"
-    t.string "description", comment: "What does this RestrictionUpgrade do?"
+    t.string "internal_description", comment: "What does this RestrictionUpgrade do?"
     t.string "type", null: false, comment: "What effect this restriction has on the upgrade"
     t.integer "uses", comment: "Number of uses this upgrade provides"
     t.integer "pop", comment: "Population cost"
@@ -380,7 +381,7 @@ ActiveRecord::Schema.define(version: 2023_02_03_194040) do
     t.bigint "unlock_id", null: false
     t.bigint "old_unit_id", null: false
     t.bigint "new_unit_id", null: false
-    t.string "description", comment: "Description of this UnitSwap"
+    t.string "internal_description", comment: "Internal description of this UnitSwap"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["new_unit_id"], name: "index_unit_swaps_on_new_unit_id"

--- a/db/seeds/doctrineabilities.csv
+++ b/db/seeds/doctrineabilities.csv
@@ -1,217 +1,217 @@
-da_id,internal_name,const,tree,branch,tier,description
-1,Bombing Run,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B1.T1,1,1,1,Bombing Run now available for purchase. 180 mu per use.
-127,Heavy Recon,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B1.T2,1,1,2,M8 and T17 now take 15% less received accuracy while moving.
-201,Behind Enemy Lines,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B1.T3,1,1,3,Airborne squads can purchase radios allowing them to capture unconnected territory.
-2,Pitching Practice,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B2.T1,1,2,1,"All Airborne may now throw Grenades and Smoke Grenades 50% further, as well as from buildings. Satchels may also be thrown 50% further."
-128,Hellhounds,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B2.T2,1,2,2,Allows the Hellcat to purchase the Staghound 50.Cal. Ambush bonus now last for a second shot. Lowers turret rotation speed by 20%.
-202,Flamethrower Envy,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B2.T3,1,2,3,Sherman Crocs can purchase a .50 cal turret MG. Engineer Flamethrowers gain +5 range and +15% damage.
-4,Big Boom,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B1.T1,2,1,1,All Airborne now throw a second Satchel Charge after throwing the first.
-129,Long Range Options,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B1.T2,2,1,2,"All Airborne may equip 4 Ranger Garands for free, and may purchase up to 2 M1919A6 LMGs for 90 MU."
-203,Raid Assault,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B1.T3,2,1,3,"Airborne have +10% sightrange, accuracy, health, and 50% reduced ability cooldowns for 60 seconds after a drop. Fireup grants heroic charge bonuses and extra speed. | Testing, use at your own risk"
-5,Weighted Packs,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B2.T1,2,2,1,All purely airdropped platoons deploy 50% faster. Includes Airborne support teams.
-130,Improved Carbines,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B2.T2,2,2,2,All Airborne may equip 4 M1A1 Carbines for free. Assault Airborne Thompson upgrade is replaced by M2 Carbines.
-204,Tier 3 alpha,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B2.T3,2,2,3,""
-7,Support Teams,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B1.T1,3,1,1,"Machine Guns, Mortars, and Anti-Tank Guns now have Airborne crews. Mortars and Machine Guns may also use fireup when they have these crews."
-131,Medical Supplies,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B1.T2,3,1,2,Medical Crates now available for purchase. Airdrops a supply crate which quickly heals nearby infantry for a short duration. 55 mu per use.
-205,Tier 3 alpha,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B1.T3,3,1,3,""
-8,Recon Run,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B2.T1,3,2,1,Recon Run (120mu 8min cd) and Smoke Run (90mu 7 min cd) are now available for purchase.
-132,Strafing Run,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B2.T2,3,2,2,Strafing Run now available for purchase. 110 mu per use.
-206,Tier 3 alpha,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B2.T3,3,2,3,""
-19,Mechanics,OMGDOCUPG.ALLY.ARMOUR.TR1.B1.T1,1,1,1,Jeeps and M3 Half-tracks (excluding quads) now have Bren Carrier Self-Repair.
-115,Patton's War,OMGDOCUPG.ALLY.ARMOUR.TR1.B1.T2,1,1,2,All platoons with tanks or vehicles (excluding Jeeps) will arrive on field instantly.
-189,Red Ones Go Faster,OMGDOCUPG.ALLY.ARMOUR.TR1.B1.T3,1,1,3,Halftracks gain overdrive and 50% faster turret rotation. Quad .50s gain overdrive and 25% faster turret rotation.
-116,Tracking the Tracks,OMGDOCUPG.ALLY.ARMOUR.TR1.B2.T2,1,3,2,"Mechanized Infantry, Snipers, Jeeps, and Armored Cars gain the &amp;quot;Tracking the Tracks&amp;quot; ability to use on enemy vehicles, which grants 1.2 received accuracy, penetration, and fog of war detection."
-190,Alternative Rounds,OMGDOCUPG.ALLY.ARMOUR.TR1.B2.T3,1,3,3,Calliopes can fire an armour piercing barrage. Sherman 105 can fire bunker buster and smoke rounds.
-21,Specialized Optics,OMGDOCUPG.ALLY.ARMOUR.TR1.B3.T1,1,3,1,"M10s, M18s, M36, and Easy Eights now have +5 sight range."
-22,TC Can Do His Job!,OMGDOCUPG.ALLY.ARMOUR.TR2.B1.T1,2,1,1,Purchasing the 50 cal machine gun upgrade on vehicles now also increase line of sight by 5.
-117,Smokey Shots,OMGDOCUPG.ALLY.ARMOUR.TR2.B1.T2,2,1,2,Shermans and Pershings may fire smoke rounds.
-191,Tier 3 alpha,OMGDOCUPG.ALLY.ARMOUR.TR2.B1.T3,2,1,3,""
-23,A Tool For Every Job,OMGDOCUPG.ALLY.ARMOUR.TR2.B2.T1,2,2,1,"All Sherman variants may now purchase either the Mine flail or Bulldozer. Bulldozers and Mine flails reduce speed by 25% instead of 50%. In addition, Mine fails give 10% more hitpoints."
-118,Next Generation Vehicles,OMGDOCUPG.ALLY.ARMOUR.TR2.B2.T2,2,2,2,"Increases acceleration, deceleration, and turret rotation on all tanks except the 105 and E8 by 25%."
-192,Tier 3 alpha,OMGDOCUPG.ALLY.ARMOUR.TR2.B2.T3,2,2,3,""
-119,Take and Hold,OMGDOCUPG.ALLY.ARMOUR.TR3.B1.T2,3,2,2,All nontank vehicles except jeeps may now capture territory.
-193,Tier 3 alpha,OMGDOCUPG.ALLY.ARMOUR.TR3.B1.T3,3,2,3,""
-26,Quadruple Bypass,OMGDOCUPG.ALLY.ARMOUR.TR3.B2.T1,3,2,1,Quad 50. Cal Halftracks may now use AP Rounds.
-120,Vehicular Repair Manuals,OMGDOCUPG.ALLY.ARMOUR.TR3.B2.T2,3,3,2,Vehicles and tanks may purchase self repair kits.
-194,Tier 3 alpha,OMGDOCUPG.ALLY.ARMOUR.TR3.B2.T3,3,3,3,""
-27,Field Mechanics,OMGDOCUPG.ALLY.ARMOUR.TR3.B3.T1,3,3,1,All Engineers can now repair 30% faster.
-10,Second Wind,OMGDOCUPG.ALLY.INFANTRY.TR1.B1.T1,1,1,1,Fire-up and Sprint cooldowns reduced by 30 seconds.
-133,Here to Clean Up This Mess,OMGDOCUPG.ALLY.INFANTRY.TR1.B1.T2,1,1,2,"Rangers are no longer purchased with bazookas. May purchase 2 Bazookas, 4 Thompsons, and/or 2 BARs."
-207,Rangers Lead the Way,OMGDOCUPG.ALLY.INFANTRY.TR1.B1.T3,1,1,3,Rifleman can replace their squad leader with a Ranger for 20mp. Those squads also recover from suppression 20% faster.
-11,Reinforced Structures,OMGDOCUPG.ALLY.INFANTRY.TR1.B2.T1,1,2,1,"Medic Tents, Triage Centers, and Machine Gun Nests have 25% more hit points."
-134,Purple Heart Soldiers,OMGDOCUPG.ALLY.INFANTRY.TR1.B2.T2,1,2,2,"Riflemen equipped with BARs receive 0.85 received damage at 5 men, an additional 0.85 received damage at 3 men, and an additional 0.85 damage at 2 men."
-208,Machine Guns as Primary Weapon,OMGDOCUPG.ALLY.INFANTRY.TR1.B2.T3,1,2,3,"Shermans receive +20% reload time, but in return hull/coaxial machine guns receive +25% increased damage, -25% cooldown, +25% burst duration and +15 range. Turret MGs receive +5 range, +25% burst duration, -25% cooldown."
-13,Setting up the Field,OMGDOCUPG.ALLY.INFANTRY.TR2.B1.T1,2,1,1,Riflemen and Ambush Riflemen can build Barbed Wire and Sandbags.
-135,Mk. 3 Potato Grenade,OMGDOCUPG.ALLY.INFANTRY.TR2.B1.T2,2,1,2,&quot;Potato Grenade&quot; ability is now given to squads who purchase grenades. Throws a fake grenade at target.
-209,Tier 3 alpha,OMGDOCUPG.ALLY.INFANTRY.TR2.B1.T3,2,1,3,""
-14,HVAP Shells,OMGDOCUPG.ALLY.INFANTRY.TR2.B2.T1,2,2,1,57mm Anti-tank Guns AP Rounds replaced with Advanced Anti-tank Gun AP Rounds.  Providing an additional +25% damage and 5 second ability duration. (REMOVE AT GUNS FROM COMPANY BEFORE PURCHASING)
-136,Smoke Will Block Out the Sky,OMGDOCUPG.ALLY.INFANTRY.TR2.B2.T2,2,2,2,"Smoke Barrage is available for purchase. 13 Smoke Shells are dropped in the designated area over time. Recharging cooldown, 90 mu."
-210,Tier 3 alpha,OMGDOCUPG.ALLY.INFANTRY.TR2.B2.T3,2,2,3,""
-16,Got a Light?,OMGDOCUPG.ALLY.INFANTRY.TR3.B1.T1,3,1,1,60mm Mortars now have M83 Flare Rounds. Lights up an area for 15 seconds.
-137,Long Tom Support,OMGDOCUPG.ALLY.INFANTRY.TR3.B1.T2,3,1,2,105 Howitzer Barrage is available for purchase. 120 mu per use.
-211,Tier 3 alpha,OMGDOCUPG.ALLY.INFANTRY.TR3.B1.T3,3,1,3,""
-17,Medical Emergency,OMGDOCUPG.ALLY.INFANTRY.TR3.B2.T1,3,2,1,Medic stations now provide 3 medics instead of 2.
-138,Snare Traps,OMGDOCUPG.ALLY.INFANTRY.TR3.B2.T2,3,2,2,"Ambush Riflemen, Riflemen, and Engineers may purchase &quot;Snare Mines&quot; which slow enemy infantry."
-212,Tier 3 alpha,OMGDOCUPG.ALLY.INFANTRY.TR3.B2.T3,3,2,3,""
-55,Deterrents,OMGDOCUPG.AXIS.BLITZ.TR1.B1.T1,16,1,1,"Coaxial and Hull Machine Guns on Tanks and armored Vehicles gain +33% fire rate, 10% incremental accuracy and 2x search radius. All tank MGs gain +5 range."
-109,Armored Advance,OMGDOCUPG.AXIS.BLITZ.TR1.B1.T2,16,1,2,Infantry within 25 unit range of tanks receive 25% less damage and 30% less suppression.
-183,Reinforced Logistics,OMGDOCUPG.AXIS.BLITZ.TR1.B1.T3,16,1,3,Repair bunkers gain a 3rd repair pioneer.
-110,Blitzkrieg!,OMGDOCUPG.AXIS.BLITZ.TR1.B2.T2,16,3,2,"Blitzkrieg available for purchase. Recharging cooldown, 150 mu."
-184,Better than Walking,OMGDOCUPG.AXIS.BLITZ.TR1.B2.T3,16,3,3,"Infantry inside halftracks regenerates at KCH speed. Infantry unloading from halftracks gain +10% accuracy,damage and sprint for 15 seconds."
-57,Dynamic Cover ,OMGDOCUPG.AXIS.BLITZ.TR1.B3.T1,16,3,1,"All Tanks, Half-Tracks, and Armored Cars may now purchase Tank Smoke for 15 Munitions."
-111,Personal Cloaking Devices,OMGDOCUPG.AXIS.BLITZ.TR2.B1.T2,17,2,2,Stormtroopers may now purchase Elite Armor instead of weapon upgrades.
-185,Tier 3 alpha,OMGDOCUPG.AXIS.BLITZ.TR2.B1.T3,17,2,3,""
-59,Organized Platoons,OMGDOCUPG.AXIS.BLITZ.TR2.B2.T1,17,2,1,Platoons with only Volksgrenadiers or Grenadiers have 75% less deployment timer.
-112,Medical Expertise,OMGDOCUPG.AXIS.BLITZ.TR2.B2.T2,17,3,2,Medpacks no longer slow squads. Walking Wounded move normally in neutral and enemy territory.
-186,Shock Effect,OMGDOCUPG.AXIS.BLITZ.TR2.B2.T3,17,3,3,"After throwing a grenade, units gain sprint and +50% suppression for 3 seconds. Assault also gains +50% suppression."
-60,Assault,OMGDOCUPG.AXIS.BLITZ.TR2.B3.T1,17,3,1,"Assault available for purchase on Volks, Stormtroopers, Grenadiers, and KCH."
-61,Panzerkrieg,OMGDOCUPG.AXIS.BLITZ.TR3.B1.T1,18,1,1," Half-tracks now have the Overdrive ability. All Vehicles and Armored Cars gain 15% additional line of sight, maneuverability, and speed."
-113,Rush to the Front!,OMGDOCUPG.AXIS.BLITZ.TR3.B1.T2,18,1,2,All Armor moves 20% faster for 15 seconds upon entering the field. All infantry sprint for 15 seconds upon entering the field.
-187,Tier 3 alpha,OMGDOCUPG.AXIS.BLITZ.TR3.B1.T3,18,1,3,""
-114,Heavy Mortar Bombardment,OMGDOCUPG.AXIS.BLITZ.TR3.B2.T2,18,3,2,Heavy Mortar Bombardment barrage available for purchase. Lightly saturates an area with mortar shells for 45 seconds. 65 mu per use.
-188,Tier 3 alpha,OMGDOCUPG.AXIS.BLITZ.TR3.B2.T3,18,3,3,""
-63,Artillery Observation,OMGDOCUPG.AXIS.BLITZ.TR3.B3.T1,18,3,1,"Designate an area in the FoW for a flare to fired into. Flare makes a small area in the fog of war visible. Recharging cooldown, 60 mu."
-73,Advanced Warning,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B1.T1,10,1,1,"Grenadiers, Volksgrenadiers, Knight Cross Holders, and Pioneers now have +4 sight range."
-121,Leadership,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B1.T2,10,1,2,Officers may now supervise all infantry in an aura around them (20% accuracy) but are immobile while doing so. Medics can purchase LMG42 and Officer may also purchase LMG42 or Panzershreck.
-195,Charismatic Leaders,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B1.T3,10,1,3,Officers can purchase an upgrade granting Lieutenant aura buffs in exchange for -35% maximum hitpoints on the officer.
-74,Karbines,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B2.T1,10,2,1,Grenadier Rifles may now be purchased for support weapons and Pioneers for 5 Munitions.
-122,Surplus Munitions,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B2.T2,10,2,2,Volksgrenadiers and Pioneers may purchase Grenades. Burst length increased by 10% on LMG42s and 25% on Volksgrenadier MP40s.
-196,Effective Triage,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B2.T3,10,2,3,Medic bunkers create Grenadier Walking Wounded instead of Volksgrenadier Walking Wounded.
-76,Stuka Barrages,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B1.T1,11,1,1,Walking Stukas now have Incendiary and Smoke Barrages.
-123,Gun Crews,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B1.T2,11,1,2,"MG42 Teams, and Mortars gain the Sprint ability. Pak38s and Nebelwerfers move faster."
-197,Tier 3 alpha,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B1.T3,11,1,3,""
-77,Heavy Support,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B2.T1,11,2,1,"Support weapons have +1 resupply. In addition, all support weapons have 15% more hitpoints on the weapon."
-124,Rocket Artillery,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B2.T2,11,2,2,&quot;Rocket Artillery&quot; barrages are available for purchase. 130 mu.
-198,Tier 3 alpha,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B2.T3,11,2,3,""
-79,Registered Artillery,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B1.T1,12,1,1,"Registered Artillery available for purchase, deploying defensive artillery barrages on allied bunkers. Recharging cooldown, 90 mu."
-125,Stronghold,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B1.T2,12,1,2,All Bunkers gain 30% more health. Garrisoned infantry slowly heal and gain +5% accuracy per minute. Caps at +15%
-199,Scar Bunker Test,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B1.T3,12,1,3,""
-80,Entrenchment,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B2.T1,12,2,1,"Sandbags, Barbed Wire, and Tank Traps build 25% faster and have 50% more health."
-126,For the Fatherland,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B2.T2,12,2,2,"For the Fatherland available for purchase, granting powerful defensive bonuses to infantry in friendly territory. Recharging cooldown, 150 mu."
-200,Tier 3 alpha (FP),OMGDOCUPG.AXIS.DEFENSIVE.TR3.B2.T3,12,2,3,""
-64,Indoctrination,OMGDOCUPG.AXIS.TERROR.TR1.B1.T1,13,1,1,"Volksgrenadiers and Sturmpioneers gain +5% accuracy and -5% received suppression per man lost, +5hp on first casualty, -10% cooldown for every extra loss. Pioneers and Saboteurs take 0.85 received suppression."
-157,Heroes of the Wehrmacht,OMGDOCUPG.AXIS.TERROR.TR1.B1.T2,13,1,2, Knights Cross Holders and Terror Officers inspire nearby troops to fight better. They are 10% more accurate and receive 10% less damage.
-231,Robotics,OMGDOCUPG.AXIS.TERROR.TR1.B1.T3,13,1,3,Goliaths gain line of sight.
-158,Rain of Fire,OMGDOCUPG.AXIS.TERROR.TR1.B2.T2,13,3,2,"Hostile Infantry in the target area of Stuka and Nebelwerfer barrages may be slowed before the barrage hits. Nebelwerfer rockets now travel 50% faster, fire 33% faster, and have a 30% larger suppression radius. "
-232,In the Name of the King,OMGDOCUPG.AXIS.TERROR.TR1.B2.T3,13,3,3,Infantry within 30m of the King Tiger gain 20% increased accuracy.
-66,Snap Shooting,OMGDOCUPG.AXIS.TERROR.TR1.B3.T1,13,3,1,Snipers have 50% less setup time and 15% cooldown reduction.
-159,Medical Reformation,OMGDOCUPG.AXIS.TERROR.TR2.B1.T2,14,2,2,Walking Wounded squads return to the field with 2 MP40s and Panzerfausts.
-233,Tier 3 alpha,OMGDOCUPG.AXIS.TERROR.TR2.B1.T3,14,2,3,""
-68,Hunter Killers,OMGDOCUPG.AXIS.TERROR.TR2.B2.T1,14,2,1,Pioneers and Sturmpioneers may purchase Volksgrenadier Rifles for free.
-160,Firestorm,OMGDOCUPG.AXIS.TERROR.TR2.B2.T2,14,3,2,Firestorm barrage now unlocked for purchase. 110 mu per use.
-234,Tier 3 alpha,OMGDOCUPG.AXIS.TERROR.TR2.B2.T3,14,3,3,""
-69,Perfectionism,OMGDOCUPG.AXIS.TERROR.TR2.B3.T1,14,3,1,"Pioneers and Sturmpioneers may now purchase Perfectionism Repairs, which repairs at 0.8 speed and 0.165 wear and tear."
-161,Burst of Fury,OMGDOCUPG.AXIS.TERROR.TR3.B1.T2,15,2,2,"Inspired Assault ability now available for purchase, granting infantry powerful offensive bonuses while making them more vulnerable to incoming fire. Recharging cooldown, 85 mu."
-235,Tier 3 alpha,OMGDOCUPG.AXIS.TERROR.TR3.B1.T3,15,2,3,""
-71,Tracer Rounds,OMGDOCUPG.AXIS.TERROR.TR3.B2.T1,15,2,1,MG42s grant 1.1 received accuracy on the target they are firing on.
-162,Propaganda Ministry,OMGDOCUPG.AXIS.TERROR.TR3.B2.T2,15,3,2,Propaganda Towers may now be built by Pioneers for 1 population. Propaganda Towers reduce accuracy by 15% and increase received suppression by 15% on nearby enemy infantry.
-236,Tier 3 alpha,OMGDOCUPG.AXIS.TERROR.TR3.B2.T3,15,3,3,""
-72,Fog of War,OMGDOCUPG.AXIS.TERROR.TR3.B3.T1,15,3,1,"Offmap ability which lowers LoS and Stealth Detection of all the squads within a circle for a short time. Recharging cooldown, 50 mu."
-46,Release the Hounds,OMGDOCUPG.CMW.COMMANDO.TR1.B1.T1,34,1,1,Bren Gun Carriers now have an ability which adds +10 sight range and grants +18 stealth detection.
-151,Disappearing Act,OMGDOCUPG.CMW.COMMANDO.TR1.B1.T2,34,1,2,&quot;Concealing Smoke&quot; cloaks units 30% longer.
-225,Commando Officers,OMGDOCUPG.CMW.COMMANDO.TR1.B1.T3,34,1,3,LTs and Captains gain Commando smoke on a 5 minute cooldown. LTs get an unreasonable increase in health.
-47,Packing Heat,OMGDOCUPG.CMW.COMMANDO.TR1.B2.T1,34,2,1,"Lieutenants and Captains may now purchase Commando Grenades for 40 Munitions, a PIAT for 30 Munitions, a Bren Gun for 20 Munitions, or a Boys AT Rifle for free."
-152,Commando Fire Teams,OMGDOCUPG.CMW.COMMANDO.TR1.B2.T2,34,2,2,"PIAT Commandos may purchase a fourth squad member. They may also choose to swap their PIATs for Three Bren Guns with a 20 MU refund, or Three Boys AT Rifles and a 60 MU refund."
-226,Commando Hospitals,OMGDOCUPG.CMW.COMMANDO.TR1.B2.T3,34,2,3,Gilder CCS is available for deployment. [Bugged]
-49,Quick Reaction Force,OMGDOCUPG.CMW.COMMANDO.TR2.B1.T1,35,1,1,Pure Commando platoons now deploy 75% faster (including Polish Paras and gliders).
-153,25 Pounder Artillery Barrage,OMGDOCUPG.CMW.COMMANDO.TR2.B1.T2,35,1,2,25 Pounder Artillery Barrage (80 mu per use) and Decoy Smoke (5 mu per use) now available for purchase.
-227,Tier 3 alpha,OMGDOCUPG.CMW.COMMANDO.TR2.B1.T3,35,1,3,""
-50,Glider Support,OMGDOCUPG.CMW.COMMANDO.TR2.B2.T1,35,2,1,Armor and Infantry Gliders are now available for use.
-154,Glider Army,OMGDOCUPG.CMW.COMMANDO.TR2.B2.T2,35,2,2,Glider deployment timer reduced by half. Troops fireup for ten seconds after exiting gliders.
-228,Tier 3 alpha,OMGDOCUPG.CMW.COMMANDO.TR2.B2.T3,35,2,3,""
-52,Priority Targets,OMGDOCUPG.CMW.COMMANDO.TR3.B1.T1,36,1,1,Lieutenants and Captains are granted an ability which tracks enemy units in the fog of war.
-155,Triangulation (4 VP),OMGDOCUPG.CMW.COMMANDO.TR3.B1.T2,36,1,2,Radio Triangulation Devices now available for purchase. Can be placed by Sappers and Commandos. 120 mu. [Bugged]
-229,Tier 3 alpha,OMGDOCUPG.CMW.COMMANDO.TR3.B1.T3,36,1,3,""
-53,Radio Disruption,OMGDOCUPG.CMW.COMMANDO.TR3.B2.T1,36,2,1,"Units within 7.5 unit radius of Radio Disruption offmap ability gain camouflage temporarily for 5 seconds, but weapons are disabled. Applies only to your own units. Recharging cooldown, 100 mu."
-156,Proper Encryption,OMGDOCUPG.CMW.COMMANDO.TR3.B2.T2,36,2,2,"Proper Encryption ability now available for purchase. Blurs enemy minimap and tactical map and reduces enemy units' sight by five meters while active. Recharging cooldown, 80 mu."
-230,Tier 3 alpha,OMGDOCUPG.CMW.COMMANDO.TR3.B2.T3,36,2,3,""
-28,Mechanized Escorts,OMGDOCUPG.CMW.ENGINEERS.TR1.B1.T1,28,1,1,"Emplacement trucks have 50% higher speed, acceleration, and deceleration along with 20% more hitpoints. In addition, 25 Pounders and Bofors now have 35% more hitpoints and gain the Hunker Down ability."
-139,Prepared Fighting Positions,OMGDOCUPG.CMW.ENGINEERS.TR1.B1.T2,28,1,2,"When in proper emplacements, Vickers Machine Gun and 3 Inch Mortars receive Lieutenant buff[BUGGED]. 17 Pounder Nests will provide Captain aura buff to the sector(working)"
-213,AVRE Piat,OMGDOCUPG.CMW.ENGINEERS.TR1.B1.T3,28,1,3,"The AVRE gains a high penetration, low AoE anti-tank shell capable of doing significant damage."
-29,I need drugs NOW!,OMGDOCUPG.CMW.ENGINEERS.TR1.B2.T1,28,2,1,Casualty Clearing Station have 30% less cooldown timer and +10 healing radius.
-140,The Greatest Heroes,OMGDOCUPG.CMW.ENGINEERS.TR1.B2.T2,28,2,2,Captains gain the &quot;Heroic Sit and Shoot&quot; ability which makes all infantry near the captain fight harder while moving slowly.
-214,Proactive Medics,OMGDOCUPG.CMW.ENGINEERS.TR1.B2.T3,28,2,3,CCS medics are replaced with active healing medics. [Bugged]
-31,Behaving Like Officers,OMGDOCUPG.CMW.ENGINEERS.TR2.B1.T1,29,1,1,"Tank Commanders grant 15% increased experience gain. In addition, Churchills may now purchase the Tank Commander upgrade for 25 Munitions."
-141,I Can See for Miiiiles Up Here,OMGDOCUPG.CMW.ENGINEERS.TR2.B1.T2,29,1,2,I Can See For Miles ability is given to all tanks with Tank Commanders. Grants line of sight to a selected area.
-215,Tier 3 alpha,OMGDOCUPG.CMW.ENGINEERS.TR2.B1.T3,29,1,3,""
-32,Speaking from the pulpit,OMGDOCUPG.CMW.ENGINEERS.TR2.B2.T1,29,2,1,Cromwell Command Tanks now grant Lieutenant aura buff to infantry.
-142,Maneuver Training,OMGDOCUPG.CMW.ENGINEERS.TR2.B2.T2,29,2,2,Firefly 17pdr's moving accuracy penalty is removed. Cromwell and Churchill 6pdrs' moving accuracy penalty is reduced to 0.75. All Churchills may buy mineplows.
-216,Tier 3 alpha,OMGDOCUPG.CMW.ENGINEERS.TR2.B2.T3,29,2,3,""
-34,Hulldown,OMGDOCUPG.CMW.ENGINEERS.TR3.B1.T1,30,1,1,"British Armor gains the Hulldown ability, which disables movement but grants 0.75 received penetration and 0.75 received damage."
-143,Armor Ingenuity,OMGDOCUPG.CMW.ENGINEERS.TR3.B1.T2,30,1,2,"AVRE turret rotation, acceleration, and max speed increased by 30%. Flame-Stuarts gain +5 range."
-217,Infantry Fighting Vehicle,OMGDOCUPG.CMW.ENGINEERS.TR3.B1.T3,30,1,3,Tommies and Sappers grant nearby Tanks -1% received penetration and accuracy per man. Tankshock grants nearby troops -10% rec. accuracy.
-35,Now This is a Big Sodding Gun,OMGDOCUPG.CMW.ENGINEERS.TR3.B2.T1,30,2,1,Sappers may now purchase Rifle Grenades and Bren Guns. (Clearing charges will be available with demos with a coming patch)
-144,Golden Wrenches,OMGDOCUPG.CMW.ENGINEERS.TR3.B2.T2,30,2,2,Sappers gain Golden Wrenches ability which instantly restores 100 health on tanks.
-218,Tier 3 alpha,OMGDOCUPG.CMW.ENGINEERS.TR3.B2.T3,30,2,3,""
-37,Rifled Barrels,OMGDOCUPG.CMW.RCA.TR1.B1.T1,31,1,1,"25 Pounders, Priests, and Supercharged 3 Inch Mortars have 15% less scatter and 15% more accuracy."
-145,Supercharged Shells,OMGDOCUPG.CMW.RCA.TR1.B1.T2,31,1,2,"Supercharge upgrade available on Mortars, Priests, and 25pdrs."
-219,Has been moved,OMGDOCUPG.CMW.RCA.TR1.B1.T3,31,1,3,""
-38,Cancer Causing,OMGDOCUPG.CMW.RCA.TR1.B2.T1,31,2,1,""
-146,Creeping Barrage,OMGDOCUPG.CMW.RCA.TR1.B2.T2,31,2,2,Creeping Barrage ability available for purchase. 90 mu per use. Cromwell Command Tanks are also given 1 use of Creeping Smoke Barrage.
-220,Observational Capacity,OMGDOCUPG.CMW.RCA.TR1.B2.T3,31,2,3,Captains & LTs can lockdown to gain +15 LOS.
-40,General Hospital,OMGDOCUPG.CMW.RCA.TR2.B1.T1,32,1,1,Casualty Clearing Stations now grant Lieutenant aura buff.
-147,Advanced Sighting,OMGDOCUPG.CMW.RCA.TR2.B1.T2,32,1,2,"HMG teams, Bofors, and 17 pounders which are stationary for 10 seconds or longer gain 15% more sight, 35% more stealth detection, and 10% more accuracy."
-221,Tier 3 alpha,OMGDOCUPG.CMW.RCA.TR2.B1.T3,32,1,3,""
-41,Ross Rifles,OMGDOCUPG.CMW.RCA.TR2.B2.T1,32,2,1,"Recon Sections now have +5 weapon range, as well as +10% accuracy (not stacking with LT aura)."
-148,Grit and Determination,OMGDOCUPG.CMW.RCA.TR2.B2.T2,32,2,2,&quot;Grit and Determination&quot; now useable by Tommies and SSF. Ability breaks suppression and reduces weapon cooldown by 50%. Can only be used while garrisoned.
-222,Tier 3 alpha,OMGDOCUPG.CMW.RCA.TR2.B2.T3,32,2,3,""
-43,High Velocity Ammo,OMGDOCUPG.CMW.RCA.TR3.B1.T1,33,1,1,Stuarts and Staghounds now have +5 weapon range on their cannons. Does not stack with the range bonus from command tanks.
-149,Armored Discipline,OMGDOCUPG.CMW.RCA.TR3.B1.T2,33,1,2,Tank Commanders increase accuracy by 10%. &quot;Flank Speed&quot; increases penetration by 50%.
-223,Tier 3 alpha,OMGDOCUPG.CMW.RCA.TR3.B1.T3,33,1,3,""
-44,Toolboxes,OMGDOCUPG.CMW.RCA.TR3.B2.T1,33,2,1,"Self Repair on Bren Carriers and Bren Gun Carriers now have 0.80 speed reduction instead of 0.35 speed reduction. In addition, the cooldown on Self Repair has been reduced by 15%."
-150,Carrier Tactics,OMGDOCUPG.CMW.RCA.TR3.B2.T2,33,2,2,Lockdown ability given to Bren Gun Carrier and Universal carrier which increases accuracy and suppression by 25%. Acceleration and max speed also increased 20%.
-224,Spare Room for Ammo,OMGDOCUPG.CMW.RCA.TR3.B2.T3,33,2,3,Units inside universal carriers reload 25% faster.
-100,Stuka Terror Dive,OMGDOCUPG.PE.LUFTWAFFE.TR1.B1.T1,25,1,1,Stuka Terror Dive Offmap available for purchase. Suppresses infantry in an area you select. 45 mu per use.
-175,Butterfly Bomblets,OMGDOCUPG.PE.LUFTWAFFE.TR1.B1.T2,25,1,2,Butterfly Bombs now available for purchase. 85 mu per use.
-249,Taking Notes On The Way Down,OMGDOCUPG.PE.LUFTWAFFE.TR1.B1.T3,25,1,3,Airborne units gain additional line of sight while paradropping.
-101,Elite Crews,OMGDOCUPG.PE.LUFTWAFFE.TR1.B2.T1,25,2,1,"P4IST and Wirbelwind acceleration, deceleration increased by 30%, and max speed by 20%. the P4IST also gets its turret rotation increased by 30%."
-176,Anti Tank Requisition,OMGDOCUPG.PE.LUFTWAFFE.TR1.B2.T2,25,2,2,"Fallshirmjagers may now purchase AT Rifles, or a single schreck. FallschirmjÃ¤gers and GebirgsjÃ¤gers can volley off two Panzerfaust uses in rapid succession. "
-250,Luftwaffe Dive Bomber,OMGDOCUPG.PE.LUFTWAFFE.TR1.B2.T3,25,2,3,Fast bomber that drops a single bomb with a large area of effect. 75 mu per use. Broken currrently
-103,Combat Arms Requisition,OMGDOCUPG.PE.LUFTWAFFE.TR2.B1.T1,26,1,1,"Luftwaffe Ground Forces may now purchase an LMG42, 2 G43s , or 2 Butterfly Mines. Fallschirmjagers can purchase 2 G43s."
-177,Erbsenmuster Camo,OMGDOCUPG.PE.LUFTWAFFE.TR2.B1.T2,26,1,2,"The Pak40, Marders and Scout Cars now cloak after locking down."
-251,Tier 3 alpha,OMGDOCUPG.PE.LUFTWAFFE.TR2.B1.T3,26,1,3,""
-104,We'll Hide This... Half-Track,OMGDOCUPG.PE.LUFTWAFFE.TR2.B2.T1,26,2,1,Medic Half-Tracks now camouflage when deployed.
-178,Mobile Security,OMGDOCUPG.PE.LUFTWAFFE.TR2.B2.T2,26,2,2,Wirblewinds now have +5 weapon range. Scout Cars with &quot;Support Fire&quot; upgrade receive +5 weapon range when locked down.
-252,Tier 3 alpha,OMGDOCUPG.PE.LUFTWAFFE.TR2.B2.T3,26,2,3,""
-106,Shift the Lines,OMGDOCUPG.PE.LUFTWAFFE.TR3.B1.T1,27,1,1,"Luftwaffe Ground Forces, Fallshirmjaegers and Gebirgsjaegers are granted the Sprint ability."
-179,Infiltration,OMGDOCUPG.PE.LUFTWAFFE.TR3.B1.T2,27,1,2,Fallshirmjaegers platoon can infiltrate out of buildings.
-253,Tier 3 alpha,OMGDOCUPG.PE.LUFTWAFFE.TR3.B1.T3,27,1,3,""
-107,A Valued Cargo,OMGDOCUPG.PE.LUFTWAFFE.TR3.B2.T1,27,2,1,"Flak 88 and Flakvierling Opel Blitz now has Half-track armor. In addition, the Trucks, Flak 88 and Flakvierling have 35% more hitpoints. Flakvierling have improved crews."
-180,Priority Acquisitions,OMGDOCUPG.PE.LUFTWAFFE.TR3.B2.T2,27,2,2,"Extra use for Incendiary Grenades, AT Grenades, Panzerfausts, Half-track Mines, Smoke Grenades, and Anti-Building Grenades. Fallshirmjaegers and Luftwaffe Ground Forces may purchase Incendiary and AT Grenades."
-254,Tier 3 alpha,OMGDOCUPG.PE.LUFTWAFFE.TR3.B2.T3,27,2,3,""
-82,Burning Bombardment,OMGDOCUPG.PE.SCORCHED.TR1.B1.T1,22,1,1,Burning Bombardment Offmap Artillery is unlocked for purchase. 45 mu.
-163,Fiery Crescendo,OMGDOCUPG.PE.SCORCHED.TR1.B1.T2,22,1,2,"Hummels, Hotchkai with Stuka, and Sturmpanzers may now fire Incendiary Barrages."
-237,Counter Offensive,OMGDOCUPG.PE.SCORCHED.TR1.B1.T3,22,1,3,"Offmap available for purchase that provides all units outside friendly territory -25% damage and infantry units -25% received suppression. Recharging cooldown, 120 mu."
-83,Increased Payloads,OMGDOCUPG.PE.SCORCHED.TR1.B2.T1,22,2,1,"Hummels fire an extra shell on their normal barrage. In addition, Mortar Half-tracks fire two extra shells in its barrage ability."
-164,Surplus Armaments,OMGDOCUPG.PE.SCORCHED.TR1.B2.T2,22,2,2,Panzer IV ISTs' weapon range is increased by five and may purchase &quot;White Phosphorous&quot; rounds.
-238,Molotov Cocktails,OMGDOCUPG.PE.SCORCHED.TR1.B2.T3,22,2,3,"Molotovs are unlocked for purchase on Ostfront Vets. A longer range sticky bomb style projectile that sets tanks on fire doing minor damage over time, -40% speed reduction, -75% sight."
-85,Steady Aim,OMGDOCUPG.PE.SCORCHED.TR2.B1.T1,23,1,1,Suppressive Volley Fire on G43s can be used while garrisoned in buildings and the Slow effect  lasts 15% longer.
-165,Ignoring the Wounds,OMGDOCUPG.PE.SCORCHED.TR2.B1.T2,23,1,2,Forward HQ ability unlocks and allows you to capture an occupied building which heals nearby infantry.On a long cooldown with unlimited uses.
-239,Nosferatu,OMGDOCUPG.PE.SCORCHED.TR2.B1.T3,23,1,3,"Deployed Vampire Halftracks reduce healing and repair speeds of all enemy units in the sector. (WIP, not yet fully implemented)"
-86,The Hand That Destroys,OMGDOCUPG.PE.SCORCHED.TR2.B2.T1,23,2,1,Incendiary Grenades now burn 5 seconds longer.
-166,Third Degree Burns,OMGDOCUPG.PE.SCORCHED.TR2.B2.T2,23,2,2,Two Incendiary Grenades are now thrown with every use.
-240,Tier 3 alpha,OMGDOCUPG.PE.SCORCHED.TR2.B2.T3,23,2,3,""
-88,Warm Welcome,OMGDOCUPG.PE.SCORCHED.TR3.B1.T1,24,1,1,All infantry may now purchase building Booby Traps.
-167,Forsaken Ground,OMGDOCUPG.PE.SCORCHED.TR3.B1.T2,24,1,2,"Booby Traps will be available for purchase on all infantry, these may deployed on the field, this can combine with &quot;Warm Welcome&quot;."
-241,Sector Artillery,OMGDOCUPG.PE.SCORCHED.TR3.B1.T3,24,1,3,Designates Sector for auto-targeting incendiary Artillery. TESTING: Currently non-functional until further notice.
-168,Take and Deny,OMGDOCUPG.PE.SCORCHED.TR3.B2.T2,24,3,2,Scorched Earth ability available for use. Disables one neutral or friendly sector for three minutes and reduces the benefits of cover.
-242,Trade Space For Time,OMGDOCUPG.PE.SCORCHED.TR3.B2.T3,24,3,3,""
-90,Immovable Objects,OMGDOCUPG.PE.SCORCHED.TR3.B3.T1,24,3,1,All Infantry may now build Roadblocks and Wire.
-91,Faustpatrone,OMGDOCUPG.PE.TANKHUNTERS.TR1.B1.T1,19,1,1,All Panzergrenadier variants may now purchase Panzerfausts.
-169,Advanced Anti-Tank Tactics,OMGDOCUPG.PE.TANKHUNTERS.TR1.B1.T2,19,1,2,"Light AT Half-Tracks' weapon range increased by five and &quot;Treadbreaker&quot; cooldown reduced one third. Hetzers can now rotate while cloaked, have faster tracking speed, and do extra ambush damage."
-243,Here was Advanced Half-tracks,OMGDOCUPG.PE.TANKHUNTERS.TR1.B1.T3,19,1,3,""
-92,Fully Aware,OMGDOCUPG.PE.TANKHUNTERS.TR1.B2.T1,19,2,1,Vampire Half-tracks are now granted Tank Awareness and 15% increased sight range.
-170,Tank Awareness,OMGDOCUPG.PE.TANKHUNTERS.TR1.B2.T2,19,2,2,All infantry now have &quot;Tank Awareness.&quot;
-244,Time to Aim,OMGDOCUPG.PE.TANKHUNTERS.TR1.B2.T3,19,2,3,"Locked down vehicles get +5 Line of sight, and 3 range on primary weapons over 12 seconds."
-94,APCR Ammunition,OMGDOCUPG.PE.TANKHUNTERS.TR2.B1.T1,20,1,1,"Marders, Hetzers, ATHTs, and Panthers may purchase the APCR rounds upgrade."
-171,Mechanized Tactics,OMGDOCUPG.PE.TANKHUNTERS.TR2.B1.T2,20,1,2,"Infantry inside Infantry Half-Tracks are 15% more accurate. Panzer Grenadier may now purchase MP40s. Scout Cars, Armored Cars, Infantry Half-tracks, Mortar Half-tracks, and Light AT Half-tracks may now purchase improved armor."
-245,Advanced Halftracks,OMGDOCUPG.PE.TANKHUNTERS.TR2.B1.T3,20,1,3,"Infantry Halftrack MGs gain +20% burst duration and tracking speed, Mortar Halftrack gains +5 range and the Vampire Halftrack gains +250HP."
-95,All-Terrain Refits,OMGDOCUPG.PE.TANKHUNTERS.TR2.B2.T1,20,2,1,"Vehicles in cover receive 10% less damage, and suffer 66% less movement penalty. All light vehicles now have medium terrain crush (not people!)"
-172,Mobile Repair Station,OMGDOCUPG.PE.TANKHUNTERS.TR2.B2.T2,20,2,2,Bergetiger can now lock down and spawn 2 expert repair pioneers a la the Repair Bunker.
-246,Tier 3 alpha,OMGDOCUPG.PE.TANKHUNTERS.TR2.B2.T3,20,2,3,""
-97,Doubled Firepower,OMGDOCUPG.PE.TANKHUNTERS.TR3.B1.T1,21,1,1,"Tank Busters may now purchase a second Panzerschreck. In addition, AT Grenades now throw a second grenade after the first."
-173,Engineering 101,OMGDOCUPG.PE.TANKHUNTERS.TR3.B1.T2,21,1,2,Walking Wounded have Advanced Repairs. Bergetigers repair wrecks 50% faster.
-247,Tier 3 alpha,OMGDOCUPG.PE.TANKHUNTERS.TR3.B1.T3,21,1,3,""
-98,Getting Mobile,OMGDOCUPG.PE.TANKHUNTERS.TR3.B2.T1,21,2,1,"Marders, Light AT Half-tracks, Hetzers, Nashorns, and Jagdpanthers gain 20% increased acceleration and deceleration. In addition, the Marder and Nashorn can now exit its Sight Main Gun ability 50% faster."
-174,Improvised Scopes,OMGDOCUPG.PE.TANKHUNTERS.TR3.B2.T2,21,2,2,"Marders, Light AT Half-Tracks, Hotchkai, Nashhorns, Jagdpanthers and others may purchase the Spotting Scope upgrade for +10 sight range."
-248,Tier 3 alpha,OMGDOCUPG.PE.TANKHUNTERS.TR3.B2.T3,21,2,3,""
+da_id,internal_name,const,tree,branch,tier,description,vp
+1,Bombing Run,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B1.T1,1,1,1,Bombing Run now available for purchase. 180 mu per use.,3
+127,Heavy Recon,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B1.T2,1,1,2,M8 and T17 now take 15% less received accuracy while moving.,2
+201,Behind Enemy Lines,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B1.T3,1,1,3,Airborne squads can purchase radios allowing them to capture unconnected territory.,3
+2,Pitching Practice,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B2.T1,1,2,1,"All Airborne may now throw Grenades and Smoke Grenades 50% further, as well as from buildings. Satchels may also be thrown 50% further.",6
+128,Hellhounds,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B2.T2,1,2,2,Allows the Hellcat to purchase the Staghound 50.Cal. Ambush bonus now last for a second shot. Lowers turret rotation speed by 20%.,4
+202,Flamethrower Envy,OMGDOCUPG.ALLY.AIRBOURNE.TR1.B2.T3,1,2,3,Sherman Crocs can purchase a .50 cal turret MG. Engineer Flamethrowers gain +5 range and +15% damage.,3
+4,Big Boom,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B1.T1,2,1,1,All Airborne now throw a second Satchel Charge after throwing the first.,4
+129,Long Range Options,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B1.T2,2,1,2,"All Airborne may equip 4 Ranger Garands for free, and may purchase up to 2 M1919A6 LMGs for 90 MU.",5
+203,Raid Assault,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B1.T3,2,1,3,"Airborne have +10% sightrange, accuracy, health, and 50% reduced ability cooldowns for 60 seconds after a drop. Fireup grants heroic charge bonuses and extra speed. | Testing, use at your own risk",5
+5,Weighted Packs,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B2.T1,2,2,1,All purely airdropped platoons deploy 50% faster. Includes Airborne support teams.,2
+130,Improved Carbines,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B2.T2,2,2,2,All Airborne may equip 4 M1A1 Carbines for free. Assault Airborne Thompson upgrade is replaced by M2 Carbines.,5
+204,Tier 3 alpha,OMGDOCUPG.ALLY.AIRBOURNE.TR2.B2.T3,2,2,3,"",1000
+7,Support Teams,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B1.T1,3,1,1,"Machine Guns, Mortars, and Anti-Tank Guns now have Airborne crews. Mortars and Machine Guns may also use fireup when they have these crews.",3
+131,Medical Supplies,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B1.T2,3,1,2,Medical Crates now available for purchase. Airdrops a supply crate which quickly heals nearby infantry for a short duration. 55 mu per use.,5
+205,Tier 3 alpha,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B1.T3,3,1,3,"",1000
+8,Recon Run,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B2.T1,3,2,1,Recon Run (120mu 8min cd) and Smoke Run (90mu 7 min cd) are now available for purchase.,2
+132,Strafing Run,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B2.T2,3,2,2,Strafing Run now available for purchase. 110 mu per use.,3
+206,Tier 3 alpha,OMGDOCUPG.ALLY.AIRBOURNE.TR3.B2.T3,3,2,3,"",1000
+19,Mechanics,OMGDOCUPG.ALLY.ARMOUR.TR1.B1.T1,1,1,1,Jeeps and M3 Half-tracks (excluding quads) now have Bren Carrier Self-Repair.,2
+115,Patton's War,OMGDOCUPG.ALLY.ARMOUR.TR1.B1.T2,1,1,2,All platoons with tanks or vehicles (excluding Jeeps) will arrive on field instantly.,5
+189,Red Ones Go Faster,OMGDOCUPG.ALLY.ARMOUR.TR1.B1.T3,1,1,3,Halftracks gain overdrive and 50% faster turret rotation. Quad .50s gain overdrive and 25% faster turret rotation.,3
+116,Tracking the Tracks,OMGDOCUPG.ALLY.ARMOUR.TR1.B2.T2,1,3,2,"Mechanized Infantry, Snipers, Jeeps, and Armored Cars gain the &amp;quot;Tracking the Tracks&amp;quot; ability to use on enemy vehicles, which grants 1.2 received accuracy, penetration, and fog of war detection.",4
+190,Alternative Rounds,OMGDOCUPG.ALLY.ARMOUR.TR1.B2.T3,1,3,3,Calliopes can fire an armour piercing barrage. Sherman 105 can fire bunker buster and smoke rounds.,3
+21,Specialized Optics,OMGDOCUPG.ALLY.ARMOUR.TR1.B3.T1,1,3,1,"M10s, M18s, M36, and Easy Eights now have +5 sight range.",3
+22,TC Can Do His Job!,OMGDOCUPG.ALLY.ARMOUR.TR2.B1.T1,2,1,1,Purchasing the 50 cal machine gun upgrade on vehicles now also increase line of sight by 5.,5
+117,Smokey Shots,OMGDOCUPG.ALLY.ARMOUR.TR2.B1.T2,2,1,2,Shermans and Pershings may fire smoke rounds.,2
+191,Tier 3 alpha,OMGDOCUPG.ALLY.ARMOUR.TR2.B1.T3,2,1,3,"",1000
+23,A Tool For Every Job,OMGDOCUPG.ALLY.ARMOUR.TR2.B2.T1,2,2,1,"All Sherman variants may now purchase either the Mine flail or Bulldozer. Bulldozers and Mine flails reduce speed by 25% instead of 50%. In addition, Mine fails give 10% more hitpoints.",3
+118,Next Generation Vehicles,OMGDOCUPG.ALLY.ARMOUR.TR2.B2.T2,2,2,2,"Increases acceleration, deceleration, and turret rotation on all tanks except the 105 and E8 by 25%.",6
+192,Tier 3 alpha,OMGDOCUPG.ALLY.ARMOUR.TR2.B2.T3,2,2,3,"",1000
+119,Take and Hold,OMGDOCUPG.ALLY.ARMOUR.TR3.B1.T2,3,2,2,All nontank vehicles except jeeps may now capture territory.,5
+193,Tier 3 alpha,OMGDOCUPG.ALLY.ARMOUR.TR3.B1.T3,3,2,3,"",1000
+26,Quadruple Bypass,OMGDOCUPG.ALLY.ARMOUR.TR3.B2.T1,3,2,1,Quad 50. Cal Halftracks may now use AP Rounds.,3
+120,Vehicular Repair Manuals,OMGDOCUPG.ALLY.ARMOUR.TR3.B2.T2,3,3,2,Vehicles and tanks may purchase self repair kits.,6
+194,Tier 3 alpha,OMGDOCUPG.ALLY.ARMOUR.TR3.B2.T3,3,3,3,"",1000
+27,Field Mechanics,OMGDOCUPG.ALLY.ARMOUR.TR3.B3.T1,3,3,1,All Engineers can now repair 30% faster.,6
+10,Second Wind,OMGDOCUPG.ALLY.INFANTRY.TR1.B1.T1,1,1,1,Fire-up and Sprint cooldowns reduced by 30 seconds.,3
+133,Here to Clean Up This Mess,OMGDOCUPG.ALLY.INFANTRY.TR1.B1.T2,1,1,2,"Rangers are no longer purchased with bazookas. May purchase 2 Bazookas, 4 Thompsons, and/or 2 BARs.",5
+207,Rangers Lead the Way,OMGDOCUPG.ALLY.INFANTRY.TR1.B1.T3,1,1,3,Rifleman can replace their squad leader with a Ranger for 20mp. Those squads also recover from suppression 20% faster.,4
+11,Reinforced Structures,OMGDOCUPG.ALLY.INFANTRY.TR1.B2.T1,1,2,1,"Medic Tents, Triage Centers, and Machine Gun Nests have 25% more hit points.",2
+134,Purple Heart Soldiers,OMGDOCUPG.ALLY.INFANTRY.TR1.B2.T2,1,2,2,"Riflemen equipped with BARs receive 0.85 received damage at 5 men, an additional 0.85 received damage at 3 men, and an additional 0.85 damage at 2 men.",4
+208,Machine Guns as Primary Weapon,OMGDOCUPG.ALLY.INFANTRY.TR1.B2.T3,1,2,3,"Shermans receive +20% reload time, but in return hull/coaxial machine guns receive +25% increased damage, -25% cooldown, +25% burst duration and +15 range. Turret MGs receive +5 range, +25% burst duration, -25% cooldown.",3
+13,Setting up the Field,OMGDOCUPG.ALLY.INFANTRY.TR2.B1.T1,2,1,1,Riflemen and Ambush Riflemen can build Barbed Wire and Sandbags.,3
+135,Mk. 3 Potato Grenade,OMGDOCUPG.ALLY.INFANTRY.TR2.B1.T2,2,1,2,&quot;Potato Grenade&quot; ability is now given to squads who purchase grenades. Throws a fake grenade at target.,1
+209,Tier 3 alpha,OMGDOCUPG.ALLY.INFANTRY.TR2.B1.T3,2,1,3,"",1000
+14,HVAP Shells,OMGDOCUPG.ALLY.INFANTRY.TR2.B2.T1,2,2,1,57mm Anti-tank Guns AP Rounds replaced with Advanced Anti-tank Gun AP Rounds.  Providing an additional +25% damage and 5 second ability duration. (REMOVE AT GUNS FROM COMPANY BEFORE PURCHASING),2
+136,Smoke Will Block Out the Sky,OMGDOCUPG.ALLY.INFANTRY.TR2.B2.T2,2,2,2,"Smoke Barrage is available for purchase. 13 Smoke Shells are dropped in the designated area over time. Recharging cooldown, 90 mu.",2
+210,Tier 3 alpha,OMGDOCUPG.ALLY.INFANTRY.TR2.B2.T3,2,2,3,"",1000
+16,Got a Light?,OMGDOCUPG.ALLY.INFANTRY.TR3.B1.T1,3,1,1,60mm Mortars now have M83 Flare Rounds. Lights up an area for 15 seconds.,2
+137,Long Tom Support,OMGDOCUPG.ALLY.INFANTRY.TR3.B1.T2,3,1,2,105 Howitzer Barrage is available for purchase. 120 mu per use.,3
+211,Tier 3 alpha,OMGDOCUPG.ALLY.INFANTRY.TR3.B1.T3,3,1,3,"",1000
+17,Medical Emergency,OMGDOCUPG.ALLY.INFANTRY.TR3.B2.T1,3,2,1,Medic stations now provide 3 medics instead of 2.,2
+138,Snare Traps,OMGDOCUPG.ALLY.INFANTRY.TR3.B2.T2,3,2,2,"Ambush Riflemen, Riflemen, and Engineers may purchase &quot;Snare Mines&quot; which slow enemy infantry.",4
+212,Tier 3 alpha,OMGDOCUPG.ALLY.INFANTRY.TR3.B2.T3,3,2,3,"",1000
+55,Deterrents,OMGDOCUPG.AXIS.BLITZ.TR1.B1.T1,16,1,1,"Coaxial and Hull Machine Guns on Tanks and armored Vehicles gain +33% fire rate, 10% incremental accuracy and 2x search radius. All tank MGs gain +5 range.",1
+109,Armored Advance,OMGDOCUPG.AXIS.BLITZ.TR1.B1.T2,16,1,2,Infantry within 25 unit range of tanks receive 25% less damage and 30% less suppression.,6
+183,Reinforced Logistics,OMGDOCUPG.AXIS.BLITZ.TR1.B1.T3,16,1,3,Repair bunkers gain a 3rd repair pioneer.,4
+110,Blitzkrieg!,OMGDOCUPG.AXIS.BLITZ.TR1.B2.T2,16,3,2,"Blitzkrieg available for purchase. Recharging cooldown, 150 mu.",4
+184,Better than Walking,OMGDOCUPG.AXIS.BLITZ.TR1.B2.T3,16,3,3,"Infantry inside halftracks regenerates at KCH speed. Infantry unloading from halftracks gain +10% accuracy,damage and sprint for 15 seconds.",3
+57,Dynamic Cover ,OMGDOCUPG.AXIS.BLITZ.TR1.B3.T1,16,3,1,"All Tanks, Half-Tracks, and Armored Cars may now purchase Tank Smoke for 15 Munitions.",3
+111,Personal Cloaking Devices,OMGDOCUPG.AXIS.BLITZ.TR2.B1.T2,17,2,2,Stormtroopers may now purchase Elite Armor instead of weapon upgrades.,3
+185,Tier 3 alpha,OMGDOCUPG.AXIS.BLITZ.TR2.B1.T3,17,2,3,"",1000
+59,Organized Platoons,OMGDOCUPG.AXIS.BLITZ.TR2.B2.T1,17,2,1,Platoons with only Volksgrenadiers or Grenadiers have 75% less deployment timer.,3
+112,Medical Expertise,OMGDOCUPG.AXIS.BLITZ.TR2.B2.T2,17,3,2,Medpacks no longer slow squads. Walking Wounded move normally in neutral and enemy territory.,6
+186,Shock Effect,OMGDOCUPG.AXIS.BLITZ.TR2.B2.T3,17,3,3,"After throwing a grenade, units gain sprint and +50% suppression for 3 seconds. Assault also gains +50% suppression.",2
+60,Assault,OMGDOCUPG.AXIS.BLITZ.TR2.B3.T1,17,3,1,"Assault available for purchase on Volks, Stormtroopers, Grenadiers, and KCH.",2
+61,Panzerkrieg,OMGDOCUPG.AXIS.BLITZ.TR3.B1.T1,18,1,1," Half-tracks now have the Overdrive ability. All Vehicles and Armored Cars gain 15% additional line of sight, maneuverability, and speed.",2
+113,Rush to the Front!,OMGDOCUPG.AXIS.BLITZ.TR3.B1.T2,18,1,2,All Armor moves 20% faster for 15 seconds upon entering the field. All infantry sprint for 15 seconds upon entering the field.,3
+187,Tier 3 alpha,OMGDOCUPG.AXIS.BLITZ.TR3.B1.T3,18,1,3,"",1000
+114,Heavy Mortar Bombardment,OMGDOCUPG.AXIS.BLITZ.TR3.B2.T2,18,3,2,Heavy Mortar Bombardment barrage available for purchase. Lightly saturates an area with mortar shells for 45 seconds. 65 mu per use.,3
+188,Tier 3 alpha,OMGDOCUPG.AXIS.BLITZ.TR3.B2.T3,18,3,3,"",1000
+63,Artillery Observation,OMGDOCUPG.AXIS.BLITZ.TR3.B3.T1,18,3,1,"Designate an area in the FoW for a flare to fired into. Flare makes a small area in the fog of war visible. Recharging cooldown, 60 mu.",3
+73,Advanced Warning,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B1.T1,10,1,1,"Grenadiers, Volksgrenadiers, Knight Cross Holders, and Pioneers now have +4 sight range.",5
+121,Leadership,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B1.T2,10,1,2,Officers may now supervise all infantry in an aura around them (20% accuracy) but are immobile while doing so. Medics can purchase LMG42 and Officer may also purchase LMG42 or Panzershreck.,4
+195,Charismatic Leaders,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B1.T3,10,1,3,Officers can purchase an upgrade granting Lieutenant aura buffs in exchange for -35% maximum hitpoints on the officer.,5
+74,Karbines,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B2.T1,10,2,1,Grenadier Rifles may now be purchased for support weapons and Pioneers for 5 Munitions.,3
+122,Surplus Munitions,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B2.T2,10,2,2,Volksgrenadiers and Pioneers may purchase Grenades. Burst length increased by 10% on LMG42s and 25% on Volksgrenadier MP40s.,5
+196,Effective Triage,OMGDOCUPG.AXIS.DEFENSIVE.TR1.B2.T3,10,2,3,Medic bunkers create Grenadier Walking Wounded instead of Volksgrenadier Walking Wounded.,4
+76,Stuka Barrages,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B1.T1,11,1,1,Walking Stukas now have Incendiary and Smoke Barrages.,2
+123,Gun Crews,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B1.T2,11,1,2,"MG42 Teams, and Mortars gain the Sprint ability. Pak38s and Nebelwerfers move faster.",6
+197,Tier 3 alpha,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B1.T3,11,1,3,"",1000
+77,Heavy Support,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B2.T1,11,2,1,"Support weapons have +1 resupply. In addition, all support weapons have 15% more hitpoints on the weapon.",3
+124,Rocket Artillery,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B2.T2,11,2,2,&quot;Rocket Artillery&quot; barrages are available for purchase. 130 mu.,4
+198,Tier 3 alpha,OMGDOCUPG.AXIS.DEFENSIVE.TR2.B2.T3,11,2,3,"",1000
+79,Registered Artillery,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B1.T1,12,1,1,"Registered Artillery available for purchase, deploying defensive artillery barrages on allied bunkers. Recharging cooldown, 90 mu.",1
+125,Stronghold,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B1.T2,12,1,2,All Bunkers gain 30% more health. Garrisoned infantry slowly heal and gain +5% accuracy per minute. Caps at +15%,5
+199,Scar Bunker Test,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B1.T3,12,1,3,Under Development [Storm],1000
+80,Entrenchment,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B2.T1,12,2,1,"Sandbags, Barbed Wire, and Tank Traps build 25% faster and have 50% more health.",2
+126,For the Fatherland,OMGDOCUPG.AXIS.DEFENSIVE.TR3.B2.T2,12,2,2,"For the Fatherland available for purchase, granting powerful defensive bonuses to infantry in friendly territory. Recharging cooldown, 150 mu.",3
+200,Tier 3 alpha (FP),OMGDOCUPG.AXIS.DEFENSIVE.TR3.B2.T3,12,2,3,Under development,1000
+64,Indoctrination,OMGDOCUPG.AXIS.TERROR.TR1.B1.T1,13,1,1,"Volksgrenadiers and Sturmpioneers gain +5% accuracy and -5% received suppression per man lost, +5hp on first casualty, -10% cooldown for every extra loss. Pioneers and Saboteurs take 0.85 received suppression.",4
+157,Heroes of the Wehrmacht,OMGDOCUPG.AXIS.TERROR.TR1.B1.T2,13,1,2, Knights Cross Holders and Terror Officers inspire nearby troops to fight better. They are 10% more accurate and receive 10% less damage.,6
+231,Robotics,OMGDOCUPG.AXIS.TERROR.TR1.B1.T3,13,1,3,Goliaths gain line of sight.,2
+158,Rain of Fire,OMGDOCUPG.AXIS.TERROR.TR1.B2.T2,13,3,2,"Hostile Infantry in the target area of Stuka and Nebelwerfer barrages may be slowed before the barrage hits. Nebelwerfer rockets now travel 50% faster, fire 33% faster, and have a 30% larger suppression radius. ",5
+232,In the Name of the King,OMGDOCUPG.AXIS.TERROR.TR1.B2.T3,13,3,3,Infantry within 30m of the King Tiger gain 20% increased accuracy.,4
+66,Snap Shooting,OMGDOCUPG.AXIS.TERROR.TR1.B3.T1,13,3,1,Snipers have 50% less setup time and 15% cooldown reduction.,2
+159,Medical Reformation,OMGDOCUPG.AXIS.TERROR.TR2.B1.T2,14,2,2,Walking Wounded squads return to the field with 2 MP40s and Panzerfausts.,4
+233,Tier 3 alpha,OMGDOCUPG.AXIS.TERROR.TR2.B1.T3,14,2,3,"",1000
+68,Hunter Killers,OMGDOCUPG.AXIS.TERROR.TR2.B2.T1,14,2,1,Pioneers and Sturmpioneers may purchase Volksgrenadier Rifles for free.,1
+160,Firestorm,OMGDOCUPG.AXIS.TERROR.TR2.B2.T2,14,3,2,Firestorm barrage now unlocked for purchase. 110 mu per use.,4
+234,Tier 3 alpha,OMGDOCUPG.AXIS.TERROR.TR2.B2.T3,14,3,3,"",1000
+69,Perfectionism,OMGDOCUPG.AXIS.TERROR.TR2.B3.T1,14,3,1,"Pioneers and Sturmpioneers may now purchase Perfectionism Repairs, which repairs at 0.8 speed and 0.165 wear and tear.",3
+161,Burst of Fury,OMGDOCUPG.AXIS.TERROR.TR3.B1.T2,15,2,2,"Inspired Assault ability now available for purchase, granting infantry powerful offensive bonuses while making them more vulnerable to incoming fire. Recharging cooldown, 85 mu.",2
+235,Tier 3 alpha,OMGDOCUPG.AXIS.TERROR.TR3.B1.T3,15,2,3,"",1000
+71,Tracer Rounds,OMGDOCUPG.AXIS.TERROR.TR3.B2.T1,15,2,1,MG42s grant 1.1 received accuracy on the target they are firing on.,3
+162,Propaganda Ministry,OMGDOCUPG.AXIS.TERROR.TR3.B2.T2,15,3,2,Propaganda Towers may now be built by Pioneers for 1 population. Propaganda Towers reduce accuracy by 15% and increase received suppression by 15% on nearby enemy infantry.,3
+236,Tier 3 alpha,OMGDOCUPG.AXIS.TERROR.TR3.B2.T3,15,3,3,"",1000
+72,Fog of War,OMGDOCUPG.AXIS.TERROR.TR3.B3.T1,15,3,1,"Offmap ability which lowers LoS and Stealth Detection of all the squads within a circle for a short time. Recharging cooldown, 50 mu.",2
+46,Release the Hounds,OMGDOCUPG.CMW.COMMANDO.TR1.B1.T1,34,1,1,Bren Gun Carriers now have an ability which adds +10 sight range and grants +18 stealth detection.,3
+151,Disappearing Act,OMGDOCUPG.CMW.COMMANDO.TR1.B1.T2,34,1,2,&quot;Concealing Smoke&quot; cloaks units 30% longer.,5
+225,Commando Officers,OMGDOCUPG.CMW.COMMANDO.TR1.B1.T3,34,1,3,LTs and Captains gain Commando smoke on a 5 minute cooldown. LTs get an unreasonable increase in health.,3
+47,Packing Heat,OMGDOCUPG.CMW.COMMANDO.TR1.B2.T1,34,2,1,"Lieutenants and Captains may now purchase Commando Grenades for 40 Munitions, a PIAT for 30 Munitions, a Bren Gun for 20 Munitions, or a Boys AT Rifle for free.",3
+152,Commando Fire Teams,OMGDOCUPG.CMW.COMMANDO.TR1.B2.T2,34,2,2,"PIAT Commandos may purchase a fourth squad member. They may also choose to swap their PIATs for Three Bren Guns with a 20 MU refund, or Three Boys AT Rifles and a 60 MU refund.",4
+226,Commando Hospitals,OMGDOCUPG.CMW.COMMANDO.TR1.B2.T3,34,2,3,Gilder CCS is available for deployment. [Bugged],4
+49,Quick Reaction Force,OMGDOCUPG.CMW.COMMANDO.TR2.B1.T1,35,1,1,Pure Commando platoons now deploy 75% faster (including Polish Paras and gliders).,2
+153,25 Pounder Artillery Barrage,OMGDOCUPG.CMW.COMMANDO.TR2.B1.T2,35,1,2,25 Pounder Artillery Barrage (80 mu per use) and Decoy Smoke (5 mu per use) now available for purchase.,3
+227,Tier 3 alpha,OMGDOCUPG.CMW.COMMANDO.TR2.B1.T3,35,1,3,"",1000
+50,Glider Support,OMGDOCUPG.CMW.COMMANDO.TR2.B2.T1,35,2,1,Armor and Infantry Gliders are now available for use.,2
+154,Glider Army,OMGDOCUPG.CMW.COMMANDO.TR2.B2.T2,35,2,2,Glider deployment timer reduced by half. Troops fireup for ten seconds after exiting gliders.,5
+228,Tier 3 alpha,OMGDOCUPG.CMW.COMMANDO.TR2.B2.T3,35,2,3,"",1000
+52,Priority Targets,OMGDOCUPG.CMW.COMMANDO.TR3.B1.T1,36,1,1,Lieutenants and Captains are granted an ability which tracks enemy units in the fog of war.,2
+155,Triangulation (4 VP),OMGDOCUPG.CMW.COMMANDO.TR3.B1.T2,36,1,2,Radio Triangulation Devices now available for purchase. Can be placed by Sappers and Commandos. 120 mu. [Bugged],100
+229,Tier 3 alpha,OMGDOCUPG.CMW.COMMANDO.TR3.B1.T3,36,1,3,"",1000
+53,Radio Disruption,OMGDOCUPG.CMW.COMMANDO.TR3.B2.T1,36,2,1,"Units within 7.5 unit radius of Radio Disruption offmap ability gain camouflage temporarily for 5 seconds, but weapons are disabled. Applies only to your own units. Recharging cooldown, 100 mu.",1
+156,Proper Encryption,OMGDOCUPG.CMW.COMMANDO.TR3.B2.T2,36,2,2,"Proper Encryption ability now available for purchase. Blurs enemy minimap and tactical map and reduces enemy units' sight by five meters while active. Recharging cooldown, 80 mu.",3
+230,Tier 3 alpha,OMGDOCUPG.CMW.COMMANDO.TR3.B2.T3,36,2,3,"",1000
+28,Mechanized Escorts,OMGDOCUPG.CMW.ENGINEERS.TR1.B1.T1,28,1,1,"Emplacement trucks have 50% higher speed, acceleration, and deceleration along with 20% more hitpoints. In addition, 25 Pounders and Bofors now have 35% more hitpoints and gain the Hunker Down ability.",1
+139,Prepared Fighting Positions,OMGDOCUPG.CMW.ENGINEERS.TR1.B1.T2,28,1,2,"When in proper emplacements, Vickers Machine Gun and 3 Inch Mortars receive Lieutenant buff[BUGGED]. 17 Pounder Nests will provide Captain aura buff to the sector(working)",3
+213,AVRE Piat,OMGDOCUPG.CMW.ENGINEERS.TR1.B1.T3,28,1,3,"The AVRE gains a high penetration, low AoE anti-tank shell capable of doing significant damage.",3
+29,I need drugs NOW!,OMGDOCUPG.CMW.ENGINEERS.TR1.B2.T1,28,2,1,Casualty Clearing Station have 30% less cooldown timer and +10 healing radius.,3
+140,The Greatest Heroes,OMGDOCUPG.CMW.ENGINEERS.TR1.B2.T2,28,2,2,Captains gain the &quot;Heroic Sit and Shoot&quot; ability which makes all infantry near the captain fight harder while moving slowly.,3
+214,Proactive Medics,OMGDOCUPG.CMW.ENGINEERS.TR1.B2.T3,28,2,3,CCS medics are replaced with active healing medics. [Bugged],4
+31,Behaving Like Officers,OMGDOCUPG.CMW.ENGINEERS.TR2.B1.T1,29,1,1,"Tank Commanders grant 15% increased experience gain. In addition, Churchills may now purchase the Tank Commander upgrade for 25 Munitions.",2
+141,I Can See for Miiiiles Up Here,OMGDOCUPG.CMW.ENGINEERS.TR2.B1.T2,29,1,2,I Can See For Miles ability is given to all tanks with Tank Commanders. Grants line of sight to a selected area.,4
+215,Tier 3 alpha,OMGDOCUPG.CMW.ENGINEERS.TR2.B1.T3,29,1,3,"",1000
+32,Speaking from the pulpit,OMGDOCUPG.CMW.ENGINEERS.TR2.B2.T1,29,2,1,Cromwell Command Tanks now grant Lieutenant aura buff to infantry.,1
+142,Maneuver Training,OMGDOCUPG.CMW.ENGINEERS.TR2.B2.T2,29,2,2,Firefly 17pdr's moving accuracy penalty is removed. Cromwell and Churchill 6pdrs' moving accuracy penalty is reduced to 0.75. All Churchills may buy mineplows.,4
+216,Tier 3 alpha,OMGDOCUPG.CMW.ENGINEERS.TR2.B2.T3,29,2,3,"",1000
+34,Hulldown,OMGDOCUPG.CMW.ENGINEERS.TR3.B1.T1,30,1,1,"British Armor gains the Hulldown ability, which disables movement but grants 0.75 received penetration and 0.75 received damage.",3
+143,Armor Ingenuity,OMGDOCUPG.CMW.ENGINEERS.TR3.B1.T2,30,1,2,"AVRE turret rotation, acceleration, and max speed increased by 30%. Flame-Stuarts gain +5 range.",3
+217,Infantry Fighting Vehicle,OMGDOCUPG.CMW.ENGINEERS.TR3.B1.T3,30,1,3,Tommies and Sappers grant nearby Tanks -1% received penetration and accuracy per man. Tankshock grants nearby troops -10% rec. accuracy.,4
+35,Now This is a Big Sodding Gun,OMGDOCUPG.CMW.ENGINEERS.TR3.B2.T1,30,2,1,Sappers may now purchase Rifle Grenades and Bren Guns. (Clearing charges will be available with demos with a coming patch),1
+144,Golden Wrenches,OMGDOCUPG.CMW.ENGINEERS.TR3.B2.T2,30,2,2,Sappers gain Golden Wrenches ability which instantly restores 100 health on tanks.,5
+218,Tier 3 alpha,OMGDOCUPG.CMW.ENGINEERS.TR3.B2.T3,30,2,3,"",1000
+37,Rifled Barrels,OMGDOCUPG.CMW.RCA.TR1.B1.T1,31,1,1,"25 Pounders, Priests, and Supercharged 3 Inch Mortars have 15% less scatter and 15% more accuracy.",3
+145,Supercharged Shells,OMGDOCUPG.CMW.RCA.TR1.B1.T2,31,1,2,"&quot;Supercharge&quot; upgrade availabe on Mortars, Priests, and 25 Pounders.",5
+219,Has been moved,OMGDOCUPG.CMW.RCA.TR1.B1.T3,31,1,3,"",25
+38,Cancer Causing,OMGDOCUPG.CMW.RCA.TR1.B2.T1,31,2,1,[No longer purchaseable. Will be replaced] ,100
+146,Creeping Barrage,OMGDOCUPG.CMW.RCA.TR1.B2.T2,31,2,2,Creeping Barrage ability available for purchase. 90 mu per use. Cromwell Command Tanks are also given 1 use of Creeping Smoke Barrage.,4
+220,Observational Capacity,OMGDOCUPG.CMW.RCA.TR1.B2.T3,31,2,3,Captains &amp; LTs can lockdown to gain +15 LOS.,3
+40,General Hospital,OMGDOCUPG.CMW.RCA.TR2.B1.T1,32,1,1,Casualty Clearing Stations now grant Lieutenant aura buff.,1
+147,Advanced Sighting,OMGDOCUPG.CMW.RCA.TR2.B1.T2,32,1,2,"HMG teams, Bofors, and 17 pounders which are stationary for 10 seconds or longer gain 15% more sight, 35% more stealth detection, and 10% more accuracy.",4
+221,Tier 3 alpha,OMGDOCUPG.CMW.RCA.TR2.B1.T3,32,1,3,"",1000
+41,Ross Rifles,OMGDOCUPG.CMW.RCA.TR2.B2.T1,32,2,1,"Recon Sections now have +5 weapon range, as well as +10% accuracy (not stacking with LT aura).",3
+148,Grit and Determination,OMGDOCUPG.CMW.RCA.TR2.B2.T2,32,2,2,&quot;Grit and Determination&quot; now useable by Tommies and SSF. Ability breaks suppression and reduces weapon cooldown by 50%. Can only be used while garrisoned.,1
+222,Tier 3 alpha,OMGDOCUPG.CMW.RCA.TR2.B2.T3,32,2,3,"",1000
+43,High Velocity Ammo,OMGDOCUPG.CMW.RCA.TR3.B1.T1,33,1,1,Stuarts and Staghounds now have +5 weapon range on their cannons. Does not stack with the range bonus from command tanks.,3
+149,Armored Discipline,OMGDOCUPG.CMW.RCA.TR3.B1.T2,33,1,2,Tank Commanders increase accuracy by 10%. &quot;Flank Speed&quot; increases penetration by 50%.,6
+223,Tier 3 alpha,OMGDOCUPG.CMW.RCA.TR3.B1.T3,33,1,3,"",1000
+44,Toolboxes,OMGDOCUPG.CMW.RCA.TR3.B2.T1,33,2,1,"Self Repair on Bren Carriers and Bren Gun Carriers now have 0.80 speed reduction instead of 0.35 speed reduction. In addition, the cooldown on Self Repair has been reduced by 15%.",1
+150,Carrier Tactics,OMGDOCUPG.CMW.RCA.TR3.B2.T2,33,2,2,Lockdown ability given to Bren Gun Carrier and Universal carrier which increases accuracy and suppression by 25%. Acceleration and max speed also increased 20%.,1
+224,Spare Room for Ammo,OMGDOCUPG.CMW.RCA.TR3.B2.T3,33,2,3,Units inside universal carriers reload 25% faster.,1
+100,Stuka Terror Dive,OMGDOCUPG.PE.LUFTWAFFE.TR1.B1.T1,25,1,1,Stuka Terror Dive Offmap available for purchase. Suppresses infantry in an area you select. 45 mu per use.,3
+175,Butterfly Bomblets,OMGDOCUPG.PE.LUFTWAFFE.TR1.B1.T2,25,1,2,Butterfly Bombs now available for purchase. 85 mu per use.,3
+249,Taking Notes On The Way Down,OMGDOCUPG.PE.LUFTWAFFE.TR1.B1.T3,25,1,3,Airborne units gain additional line of sight while paradropping.,2
+101,Elite Crews,OMGDOCUPG.PE.LUFTWAFFE.TR1.B2.T1,25,2,1,"P4IST and Wirbelwind acceleration, deceleration increased by 30%, and max speed by 20%. the P4IST also gets its turret rotation increased by 30%.",3
+176,Anti Tank Requisition,OMGDOCUPG.PE.LUFTWAFFE.TR1.B2.T2,25,2,2,"Fallshirmjagers may now purchase AT Rifles, or a single schreck. FallschirmjÃ¤gers and GebirgsjÃ¤gers can volley off two Panzerfaust uses in rapid succession. ",4
+250,Luftwaffe Dive Bomber,OMGDOCUPG.PE.LUFTWAFFE.TR1.B2.T3,25,2,3,Fast bomber that drops a single bomb with a large area of effect. 75 mu per use. Broken currrently,999
+103,Combat Arms Requisition,OMGDOCUPG.PE.LUFTWAFFE.TR2.B1.T1,26,1,1,"Luftwaffe Ground Forces may now purchase an LMG42, 2 G43s , or 2 Butterfly Mines. Fallschirmjagers can purchase 2 G43s.",4
+177,Erbsenmuster Camo,OMGDOCUPG.PE.LUFTWAFFE.TR2.B1.T2,26,1,2,"The Pak40, Marders and Scout Cars now cloak after locking down.",4
+251,Tier 3 alpha,OMGDOCUPG.PE.LUFTWAFFE.TR2.B1.T3,26,1,3,"",1000
+104,We'll Hide This... Half-Track,OMGDOCUPG.PE.LUFTWAFFE.TR2.B2.T1,26,2,1,Medic Half-Tracks now camouflage when deployed.,2
+178,Mobile Security,OMGDOCUPG.PE.LUFTWAFFE.TR2.B2.T2,26,2,2,Wirblewinds now have +5 weapon range. Scout Cars with &quot;Support Fire&quot; upgrade receive +5 weapon range when locked down.,5
+252,Tier 3 alpha,OMGDOCUPG.PE.LUFTWAFFE.TR2.B2.T3,26,2,3,"",1000
+106,Shift the Lines,OMGDOCUPG.PE.LUFTWAFFE.TR3.B1.T1,27,1,1,"Luftwaffe Ground Forces, Fallshirmjaegers and Gebirgsjaegers are granted the Sprint ability.",3
+179,Infiltration,OMGDOCUPG.PE.LUFTWAFFE.TR3.B1.T2,27,1,2,Fallshirmjaegers platoon can infiltrate out of buildings.,3
+253,Tier 3 alpha,OMGDOCUPG.PE.LUFTWAFFE.TR3.B1.T3,27,1,3,"",1000
+107,A Valued Cargo,OMGDOCUPG.PE.LUFTWAFFE.TR3.B2.T1,27,2,1,"Flak 88 and Flakvierling Opel Blitz now has Half-track armor. In addition, the Trucks, Flak 88 and Flakvierling have 35% more hitpoints. Flakvierling have improved crews.",3
+180,Priority Acquisitions,OMGDOCUPG.PE.LUFTWAFFE.TR3.B2.T2,27,2,2,"Extra use for Incendiary Grenades, AT Grenades, Panzerfausts, Half-track Mines, Smoke Grenades, and Anti-Building Grenades. Fallshirmjaegers and Luftwaffe Ground Forces may purchase Incendiary and AT Grenades.",4
+254,Tier 3 alpha,OMGDOCUPG.PE.LUFTWAFFE.TR3.B2.T3,27,2,3,"",1000
+82,Burning Bombardment,OMGDOCUPG.PE.SCORCHED.TR1.B1.T1,22,1,1,Burning Bombardment Offmap Artillery is unlocked for purchase. 45 mu.,2
+163,Fiery Crescendo,OMGDOCUPG.PE.SCORCHED.TR1.B1.T2,22,1,2,"Hummels, Hotchkai with Stuka, and Sturmpanzers may now fire Incendiary Barrages.",5
+237,Counter Offensive,OMGDOCUPG.PE.SCORCHED.TR1.B1.T3,22,1,3,"Offmap available for purchase that provides all units outside friendly territory -25% damage and infantry units -25% received suppression. Recharging cooldown, 120 mu.",4
+83,Increased Payloads,OMGDOCUPG.PE.SCORCHED.TR1.B2.T1,22,2,1,"Hummels fire an extra shell on their normal barrage. In addition, Mortar Half-tracks fire two extra shells in its barrage ability.",3
+164,Surplus Armaments,OMGDOCUPG.PE.SCORCHED.TR1.B2.T2,22,2,2,Panzer IV ISTs' weapon range is increased by five and may purchase &quot;White Phosphorous&quot; rounds.,3
+238,Molotov Cocktails,OMGDOCUPG.PE.SCORCHED.TR1.B2.T3,22,2,3,"Molotovs are unlocked for purchase on Ostfront Vets. A longer range sticky bomb style projectile that sets tanks on fire doing minor damage over time, -40% speed reduction, -75% sight.",4
+85,Steady Aim,OMGDOCUPG.PE.SCORCHED.TR2.B1.T1,23,1,1,Suppressive Volley Fire on G43s can be used while garrisoned in buildings and the Slow effect  lasts 15% longer.,3
+165,Ignoring the Wounds,OMGDOCUPG.PE.SCORCHED.TR2.B1.T2,23,1,2,Forward HQ ability unlocks and allows you to capture an occupied building which heals nearby infantry.On a long cooldown with unlimited uses.,5
+239,Nosferatu,OMGDOCUPG.PE.SCORCHED.TR2.B1.T3,23,1,3,"Deployed Vampire Halftracks reduce healing and repair speeds of all enemy units in the sector. (WIP, not yet fully implemented)",26
+86,The Hand That Destroys,OMGDOCUPG.PE.SCORCHED.TR2.B2.T1,23,2,1,Incendiary Grenades now burn 5 seconds longer.,2
+166,Third Degree Burns,OMGDOCUPG.PE.SCORCHED.TR2.B2.T2,23,2,2,Two Incendiary Grenades are now thrown with every use.,6
+240,Tier 3 alpha,OMGDOCUPG.PE.SCORCHED.TR2.B2.T3,23,2,3,"",1000
+88,Warm Welcome,OMGDOCUPG.PE.SCORCHED.TR3.B1.T1,24,1,1,All infantry may now purchase building Booby Traps.,3
+167,Forsaken Ground,OMGDOCUPG.PE.SCORCHED.TR3.B1.T2,24,1,2,"Booby Traps will be available for purchase on all infantry, these may deployed on the field, this can combine with &quot;Warm Welcome&quot;.",4
+241,Sector Artillery,OMGDOCUPG.PE.SCORCHED.TR3.B1.T3,24,1,3,Designates Sector for auto-targeting incendiary Artillery. TESTING: Currently non-functional until further notice. ,10
+168,Take and Deny,OMGDOCUPG.PE.SCORCHED.TR3.B2.T2,24,3,2,Scorched Earth ability available for use. Disables one neutral or friendly sector for three minutes and reduces the benefits of cover.,999
+242,Trade Space For Time,OMGDOCUPG.PE.SCORCHED.TR3.B2.T3,24,3,3,Under Development [Storm],1000
+90,Immovable Objects,OMGDOCUPG.PE.SCORCHED.TR3.B3.T1,24,3,1,All Infantry may now build Roadblocks and Wire.,3
+91,Faustpatrone,OMGDOCUPG.PE.TANKHUNTERS.TR1.B1.T1,19,1,1,All Panzergrenadier variants may now purchase Panzerfausts.,2
+169,Advanced Anti-Tank Tactics,OMGDOCUPG.PE.TANKHUNTERS.TR1.B1.T2,19,1,2,"Light AT Half-Tracks' weapon range increased by five and &quot;Treadbreaker&quot; cooldown reduced one third. Hetzers can now rotate while cloaked, have faster tracking speed, and do extra ambush damage.",5
+243,Here was Advanced Half-tracks,OMGDOCUPG.PE.TANKHUNTERS.TR1.B1.T3,19,1,3,This ability has been moved.,10
+92,Fully Aware,OMGDOCUPG.PE.TANKHUNTERS.TR1.B2.T1,19,2,1,Vampire Half-tracks are now granted Tank Awareness and 15% increased sight range.,2
+170,Tank Awareness,OMGDOCUPG.PE.TANKHUNTERS.TR1.B2.T2,19,2,2,All infantry now have &quot;Tank Awareness.&quot;,6
+244,Time to Aim,OMGDOCUPG.PE.TANKHUNTERS.TR1.B2.T3,19,2,3,"Locked down vehicles get +5 Line of sight, and 3 range on primary weapons over 12 seconds.",4
+94,APCR Ammunition,OMGDOCUPG.PE.TANKHUNTERS.TR2.B1.T1,20,1,1,"Marders, Hetzers, ATHTs, and Panthers may purchase the APCR rounds upgrade.",3
+171,Mechanized Tactics,OMGDOCUPG.PE.TANKHUNTERS.TR2.B1.T2,20,1,2,"Infantry inside Infantry Half-Tracks are 15% more accurate. Panzer Grenadier may now purchase MP40s. Scout Cars, Armored Cars, Infantry Half-tracks, Mortar Half-tracks, and Light AT Half-tracks may now purchase improved armor.",5
+245,Advanced Halftracks,OMGDOCUPG.PE.TANKHUNTERS.TR2.B1.T3,20,1,3,"Infantry Halftrack MGs gain +20% burst duration and tracking speed, Mortar Halftrack gains +5 range and the Vampire Halftrack gains +250HP.",4
+95,All-Terrain Refits,OMGDOCUPG.PE.TANKHUNTERS.TR2.B2.T1,20,2,1,"Vehicles in cover receive 10% less damage, and suffer 66% less movement penalty. All light vehicles now have medium terrain crush (not people!)",3
+172,Mobile Repair Station,OMGDOCUPG.PE.TANKHUNTERS.TR2.B2.T2,20,2,2,Bergetiger can now lock down and spawn 2 expert repair pioneers Ã  la the Repair Bunker.,4
+246,Tier 3 alpha,OMGDOCUPG.PE.TANKHUNTERS.TR2.B2.T3,20,2,3,"",1000
+97,Doubled Firepower,OMGDOCUPG.PE.TANKHUNTERS.TR3.B1.T1,21,1,1,"Tank Busters may now purchase a second Panzerschreck. In addition, AT Grenades now throw a second grenade after the first.",4
+173,Engineering 101,OMGDOCUPG.PE.TANKHUNTERS.TR3.B1.T2,21,1,2,Walking Wounded have Advanced Repairs. Bergetigers repair wrecks 50% faster.,4
+247,Tier 3 alpha,OMGDOCUPG.PE.TANKHUNTERS.TR3.B1.T3,21,1,3,"",1000
+98,Getting Mobile,OMGDOCUPG.PE.TANKHUNTERS.TR3.B2.T1,21,2,1,"Marders, Light AT Half-tracks, Hetzers, Nashorns, and Jagdpanthers gain 20% increased acceleration and deceleration. In addition, the Marder and Nashorn can now exit its Sight Main Gun ability 50% faster.",3
+174,Improvised Scopes,OMGDOCUPG.PE.TANKHUNTERS.TR3.B2.T2,21,2,2,"Marders, Light AT Half-Tracks, Hotchkai, Nashhorns, Jagdpanthers and others may purchase the Spotting Scope upgrade for +10 sight range.",3
+248,Tier 3 alpha,OMGDOCUPG.PE.TANKHUNTERS.TR3.B2.T3,21,2,3,"",1000

--- a/db/seeds/restriction_units.seeds.rb
+++ b/db/seeds/restriction_units.seeds.rb
@@ -117,22 +117,37 @@ after :restrictions do
                       man: 300, mun: 0, fuel: 0, pop: 6, resupply: 2, resupply_max: 4, company_max: 6, priority: 1,
                       unitwide_upgrade_slots: 1, upgrade_slots: 4)
 
+  ### Support Teams Unit Swap
+  support_teams_unlock = Unlock.find_by(name: "support_teams")
+  support_teams_doctrine_unlock = DoctrineUnlock.find_by(doctrine: airborne_doc, unlock: support_teams_unlock)
+  support_teams_restriction = Restriction.find_by(doctrine_unlock: support_teams_doctrine_unlock)
   airborne_hmg = SupportTeam.find_by_name("airborne_hmg")
-  EnabledUnit.create!(restriction: airborne_restriction, unit: airborne_hmg, ruleset: war_ruleset,
+  EnabledUnit.create!(restriction: support_teams_restriction, unit: airborne_hmg, ruleset: war_ruleset,
                       man: 300, mun: 40, fuel: 0, pop: 3, resupply: 3, resupply_max: 6, company_max: 6, priority: 1,
                       upgrade_slots: 1)
   airborne_mortar = SupportTeam.find_by_name("airborne_mortar")
-  EnabledUnit.create!(restriction: airborne_restriction, unit: airborne_mortar, ruleset: war_ruleset,
+  EnabledUnit.create!(restriction: support_teams_restriction, unit: airborne_mortar, ruleset: war_ruleset,
                       man: 430, mun: 50, fuel: 0, pop: 3, resupply: 3, resupply_max: 6, company_max: 6, priority: 1,
                       upgrade_slots: 1)
   airborne_atg = SupportTeam.find_by_name("airborne_atg")
-  EnabledUnit.create!(restriction: airborne_restriction, unit: airborne_atg, ruleset: war_ruleset,
+  EnabledUnit.create!(restriction: support_teams_restriction, unit: airborne_atg, ruleset: war_ruleset,
                       man: 480, mun: 130, fuel: 0, pop: 5, resupply: 4, resupply_max: 6, company_max: 6, priority: 1,
                       upgrade_slots: 1)
   airborne_sniper = SupportTeam.find_by_name("airborne_sniper")
-  EnabledUnit.create!(restriction: airborne_restriction, unit: airborne_sniper, ruleset: war_ruleset,
+  EnabledUnit.create!(restriction: support_teams_restriction, unit: airborne_sniper, ruleset: war_ruleset,
                       man: 600, mun: 150, fuel: 0, pop: 8, resupply: 1, resupply_max: 1, company_max: 3, priority: 1,
                       upgrade_slots: 1)
+
+  DisabledUnit.create!(restriction: support_teams_restriction, unit: _30cal_hmg, ruleset: war_ruleset)
+  DisabledUnit.create!(restriction: support_teams_restriction, unit: mortar_allied, ruleset: war_ruleset)
+  DisabledUnit.create!(restriction: support_teams_restriction, unit: _57mm_atg, ruleset: war_ruleset)
+  DisabledUnit.create!(restriction: support_teams_restriction, unit: sniper_allied, ruleset: war_ruleset)
+
+  UnitSwap.create!(unlock: support_teams_unlock, old_unit: _30cal_hmg, new_unit: airborne_hmg)
+  UnitSwap.create!(unlock: support_teams_unlock, old_unit: mortar_allied, new_unit: airborne_mortar)
+  UnitSwap.create!(unlock: support_teams_unlock, old_unit: _57mm_atg, new_unit: airborne_atg)
+  UnitSwap.create!(unlock: support_teams_unlock, old_unit: sniper_allied, new_unit: airborne_sniper)
+  ### End Support Teams Unit Swap
 
   chaffee = Tank.find_by_name("chaffee")
   EnabledUnit.create!(restriction: airborne_restriction, unit: chaffee, ruleset: war_ruleset,

--- a/db/seeds/restrictions.seeds.rb
+++ b/db/seeds/restrictions.seeds.rb
@@ -1,19 +1,13 @@
-after :units do
+after :unlocks do
   # Factions and Doctrines already have their standard Restriction created
   # This should contain unlock restrictions
 
-  # Americans
-  americans = Faction.find_by_name("americans")
-
-  ## Infantry
-  infantry = Doctrine.find_by_name("infantry")
-
-
-  ## Airborne
-  airborne = Doctrine.find_by_name("airborne")
-
-
-  ## Armor
-  armor = Doctrine.find_by_name("armor")
+  DoctrineUnlock.includes(:doctrine, :unlock).each do |du|
+    doctrine = du.doctrine
+    unlock = du.unlock
+    Restriction.create!(doctrine_unlock: du,
+                        name: "#{doctrine.display_name} | #{unlock.display_name}",
+                        description: "#{doctrine.display_name} Doctrine Unlock Restriction - #{unlock.display_name}")
+  end
 
 end

--- a/db/seeds/unlocks.seeds.rb
+++ b/db/seeds/unlocks.seeds.rb
@@ -49,26 +49,26 @@ after :units do
 
     puts "name: #{name}, constname: #{row["const"]}, doctrine: #{doctrine.display_name}"
     unlock = Unlock.create!(name: snakecase(name), const_name: row["const"], display_name: name, description: row["description"])
-    DoctrineUnlock.create!(doctrine: doctrine, unlock: unlock, tree: row["tree"], branch: row["branch"], row: row["tier"])
+    DoctrineUnlock.create!(doctrine: doctrine, unlock: unlock, vp_cost: row["vp"], tree: row["tree"], branch: row["branch"], row: row["tier"])
   end
 
-  # UnitSwaps for unlocks
-
-  ## Airborne Support Teams
-  support_teams = Unlock.find_by(name: "support_teams")
-  # old units
-  sniper_allied = Unit.find_by(name: "sniper_allied")
-  _30cal_hmg = Unit.find_by(name: "30cal_hmg")
-  mortar_allied = Unit.find_by(name: "mortar_allied")
-  _57mm_atg = Unit.find_by(name: "57mm_atg")
-  # new units
-  airborne_hmg = Unit.find_by(name: "airborne_hmg")
-  airborne_mortar = Unit.find_by(name: "airborne_mortar")
-  airborne_atg = Unit.find_by(name: "airborne_atg")
-  airborne_sniper = Unit.find_by(name: "airborne_sniper")
-  UnitSwap.create!(unlock: support_teams, old_unit: sniper_allied, new_unit: airborne_sniper)
-  UnitSwap.create!(unlock: support_teams, old_unit: _30cal_hmg, new_unit: airborne_hmg)
-  UnitSwap.create!(unlock: support_teams, old_unit: mortar_allied, new_unit: airborne_mortar)
-  UnitSwap.create!(unlock: support_teams, old_unit: _57mm_atg, new_unit: airborne_atg)
+  # # UnitSwaps for unlocks
+  #
+  # ## Airborne Support Teams
+  # support_teams = Unlock.find_by(name: "support_teams")
+  # # old units
+  # sniper_allied = Unit.find_by(name: "sniper_allied")
+  # _30cal_hmg = Unit.find_by(name: "30cal_hmg")
+  # mortar_allied = Unit.find_by(name: "mortar_allied")
+  # _57mm_atg = Unit.find_by(name: "57mm_atg")
+  # # new units
+  # airborne_hmg = Unit.find_by(name: "airborne_hmg")
+  # airborne_mortar = Unit.find_by(name: "airborne_mortar")
+  # airborne_atg = Unit.find_by(name: "airborne_atg")
+  # airborne_sniper = Unit.find_by(name: "airborne_sniper")
+  # UnitSwap.create!(unlock: support_teams, old_unit: sniper_allied, new_unit: airborne_sniper)
+  # UnitSwap.create!(unlock: support_teams, old_unit: _30cal_hmg, new_unit: airborne_hmg)
+  # UnitSwap.create!(unlock: support_teams, old_unit: mortar_allied, new_unit: airborne_mortar)
+  # UnitSwap.create!(unlock: support_teams, old_unit: _57mm_atg, new_unit: airborne_atg)
 
 end

--- a/spec/factories/base_available_unit.rb
+++ b/spec/factories/base_available_unit.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :available_unit do
+  factory :base_available_unit do
     available { 4 }
     resupply { 2 }
     resupply_max { 3 }
@@ -9,7 +9,6 @@ FactoryBot.define do
     mun { 50 }
     fuel { 40 }
     callin_modifier { 1 }
-    type { "BaseAvailableUnit" }
 
     association :company
     association :unit

--- a/spec/factories/company_unlock.rb
+++ b/spec/factories/company_unlock.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :company_unlock do
+    association :company
+    association :doctrine_unlock
+  end
+end

--- a/spec/factories/doctrine_unlock.rb
+++ b/spec/factories/doctrine_unlock.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :doctrine_unlock do
+    association :doctrine
+    association :unlock
+    tree { 1 }
+    branch { 1 }
+    row { 1 }
+  end
+end

--- a/spec/factories/restriction.rb
+++ b/spec/factories/restriction.rb
@@ -4,6 +4,21 @@ FactoryBot.define do
     description { "for a faction" }
     association :faction
   end
+
+  trait :with_doctrine do
+    faction { nil }
+    association :doctrine
+  end
+
+  trait :with_doctrine_unlock do
+    faction { nil }
+    association :doctrine_unlock
+  end
+
+  trait :with_unlock do
+    faction { nil }
+    association :unlock
+  end
 end
 
 

--- a/spec/factories/restriction_unit.rb
+++ b/spec/factories/restriction_unit.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :restriction
     association :unit
     association :ruleset
-    description { 'Restriction Unit' }
+    internal_description { 'Restriction Unit' }
     man { 100 }
     mun { 90 }
     fuel { 40 }

--- a/spec/factories/restriction_upgrade.rb
+++ b/spec/factories/restriction_upgrade.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :restriction
     association :upgrade
     association :ruleset
-    description { 'Restriction Upgrade' }
+    internal_description { 'Restriction Upgrade' }
     uses { 1 }
     man { 100 }
     mun { 90 }

--- a/spec/models/base_available_unit_spec.rb
+++ b/spec/models/base_available_unit_spec.rb
@@ -1,3 +1,34 @@
+# == Schema Information
+#
+# Table name: available_units
+#
+#  id                                                                                   :bigint           not null, primary key
+#  available(Number of this unit available to purchase for the company)                 :integer          default(0), not null
+#  callin_modifier(Calculated base callin modifier of this unit for the company)        :decimal(, )      not null
+#  company_max(Maximum number of the unit a company can hold)                           :integer          default(0), not null
+#  fuel(Calculated fuel cost of this unit for the company)                              :integer          not null
+#  man(Calculated man cost of this unit for the company)                                :integer          not null
+#  mun(Calculated mun cost of this unit for the company)                                :integer          not null
+#  pop(Calculated pop cost of this unit for the company)                                :decimal(, )      not null
+#  resupply(Per game resupply)                                                          :integer          default(0), not null
+#  resupply_max(How much resupply is available from saved up resupplies, <= company ma) :integer          default(0), not null
+#  type(Type of available unit)                                                         :string           not null
+#  created_at                                                                           :datetime         not null
+#  updated_at                                                                           :datetime         not null
+#  company_id                                                                           :bigint
+#  unit_id                                                                              :bigint
+#
+# Indexes
+#
+#  index_available_units_on_company_id                       (company_id)
+#  index_available_units_on_company_id_and_unit_id_and_type  (company_id,unit_id,type) UNIQUE
+#  index_available_units_on_unit_id                          (unit_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
+#  fk_rails_...  (unit_id => units.id)
+#
 RSpec.describe BaseAvailableUnit, type: :model do
   let!(:base_available_unit) { create :base_available_unit}
 end

--- a/spec/models/base_available_unit_spec.rb
+++ b/spec/models/base_available_unit_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe BaseAvailableUnit, type: :model do
+  let!(:base_available_unit) { create :base_available_unit}
+end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Company, type: :model do
     it { should have_many(:available_units) }
     it { should have_many(:squads) }
     it { should have_many(:company_unlocks) }
-    it { should have_many(:unlocks) }
+    it { should have_many(:doctrine_unlocks) }
     it { should have_many(:company_offmaps) }
     it { should have_many(:offmaps) }
     it { should have_many(:company_resource_bonuses) }

--- a/spec/models/company_unlock_spec.rb
+++ b/spec/models/company_unlock_spec.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: company_unlocks
+#
+#  id                 :bigint           not null, primary key
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  company_id         :bigint
+#  doctrine_unlock_id :bigint
+#
+# Indexes
+#
+#  index_company_unlocks_on_company_id          (company_id)
+#  index_company_unlocks_on_doctrine_unlock_id  (doctrine_unlock_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
+#  fk_rails_...  (doctrine_unlock_id => doctrine_unlocks.id)
+#
 require "rails_helper"
 
 RSpec.describe CompanyUnlock, type: :model do

--- a/spec/models/company_unlock_spec.rb
+++ b/spec/models/company_unlock_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe CompanyUnlock, type: :model do
+  let!(:company_unlock) { create :company_unlock }
+
+  describe 'associations' do
+    it { should belong_to(:company) }
+    it { should belong_to(:doctrine_unlock) }
+  end
+end

--- a/spec/models/disabled_unit_spec.rb
+++ b/spec/models/disabled_unit_spec.rb
@@ -41,11 +41,11 @@ require "rails_helper"
 
 RSpec.describe DisabledUnit, type: :model do
 
-  it "generates and saves the description" do
+  it "generates and saves the internal_description" do
     unit = create :infantry, display_name: "Rifles"
     restriction = create :restriction, name: "American army"
     ruleset = create :ruleset
     disabled_unit = create :disabled_unit, restriction: restriction, unit: unit, ruleset: ruleset
-    expect(disabled_unit.description).to eq("American army - Rifles - DISABLED")
+    expect(disabled_unit.internal_description).to eq("American army - Rifles - DISABLED")
   end
 end

--- a/spec/models/disabled_upgrade_spec.rb
+++ b/spec/models/disabled_upgrade_spec.rb
@@ -2,20 +2,20 @@
 #
 # Table name: restriction_upgrades
 #
-#  id                                                    :bigint           not null, primary key
-#  description(What does this RestrictionUpgrade do?)    :string
-#  fuel(Fuel cost)                                       :integer
-#  man(Manpower cost)                                    :integer
-#  mun(Munition cost)                                    :integer
-#  pop(Population cost)                                  :integer
-#  priority(Priority of this restriction)                :integer
-#  type(What effect this restriction has on the upgrade) :string           not null
-#  uses(Number of uses this upgrade provides)            :integer
-#  created_at                                            :datetime         not null
-#  updated_at                                            :datetime         not null
-#  restriction_id                                        :bigint
-#  ruleset_id                                            :bigint
-#  upgrade_id                                            :bigint
+#  id                                                          :bigint           not null, primary key
+#  fuel(Fuel cost)                                             :integer
+#  internal_description(What does this RestrictionUpgrade do?) :string
+#  man(Manpower cost)                                          :integer
+#  mun(Munition cost)                                          :integer
+#  pop(Population cost)                                        :integer
+#  priority(Priority of this restriction)                      :integer
+#  type(What effect this restriction has on the upgrade)       :string           not null
+#  uses(Number of uses this upgrade provides)                  :integer
+#  created_at                                                  :datetime         not null
+#  updated_at                                                  :datetime         not null
+#  restriction_id                                              :bigint
+#  ruleset_id                                                  :bigint
+#  upgrade_id                                                  :bigint
 #
 # Indexes
 #
@@ -33,11 +33,11 @@ require "rails_helper"
 
 RSpec.describe DisabledUpgrade, type: :model do
 
-  it "generates and saves the description" do
+  it "generates and saves the internal_description" do
     upgrade = create :upgrade, display_name: "Medkit"
     restriction = create :restriction, name: "American army"
     ruleset = create :ruleset
     disabled_upgrade = create :disabled_upgrade, restriction: restriction, upgrade: upgrade, ruleset: ruleset
-    expect(disabled_upgrade.description).to eq("American army - Medkit - DISABLED")
+    expect(disabled_upgrade.internal_description).to eq("American army - Medkit - DISABLED")
   end
 end

--- a/spec/models/doctrine_spec.rb
+++ b/spec/models/doctrine_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Doctrine, type: :model do
     it { should belong_to(:faction) }
     it { should have_many(:doctrine_unlocks) }
     it { should have_many(:unlocks) }
-    it { should have_many(:restrictions) }
+    it { should have_one(:restrictions) }
   end
 
   describe 'validations' do

--- a/spec/models/doctrine_spec.rb
+++ b/spec/models/doctrine_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Doctrine, type: :model do
     it { should belong_to(:faction) }
     it { should have_many(:doctrine_unlocks) }
     it { should have_many(:unlocks) }
-    it { should have_one(:restrictions) }
+    it { should have_one(:restriction) }
   end
 
   describe 'validations' do

--- a/spec/models/doctrine_unlock_spec.rb
+++ b/spec/models/doctrine_unlock_spec.rb
@@ -37,4 +37,10 @@ RSpec.describe DoctrineUnlock, type: :model do
     it { should have_many(:restriction_upgrades) }
     it { should have_many(:restriction_offmaps) }
   end
+
+
+  it "should construct a internal_description" do
+    expect(doctrine_unlock.internal_description)
+      .to eq "#{doctrine_unlock.doctrine.display_name} | #{doctrine_unlock.unlock.display_name}"
+  end
 end

--- a/spec/models/doctrine_unlock_spec.rb
+++ b/spec/models/doctrine_unlock_spec.rb
@@ -24,27 +24,13 @@
 #  fk_rails_...  (doctrine_id => doctrines.id)
 #  fk_rails_...  (unlock_id => unlocks.id)
 #
-class DoctrineUnlock < ApplicationRecord
-  belongs_to :doctrine
-  belongs_to :unlock
-  has_one :restriction
+require "rails_helper"
 
-  has_many :restriction_units
-  has_many :restriction_upgrades
-  has_many :restriction_offmaps
+RSpec.describe DoctrineUnlock, type: :model do
+  let!(:doctrine_unlock) { create :doctrine_unlock }
 
-  def entity
-    Entity.new(self)
-  end
-
-  class Entity < Grape::Entity
-    expose :id
-    expose :doctrine_id, as: :doctrineId
-    expose :unlock_id, as: :unlockId
-    expose :vp_cost, as: :vpCost
-    expose :tree
-    expose :branch
-    expose :row
-    expose :unlock, using: Unlock::Entity
+  describe 'associations' do
+    it { should belong_to(:doctrine) }
+    it { should belong_to(:unlock) }
   end
 end

--- a/spec/models/doctrine_unlock_spec.rb
+++ b/spec/models/doctrine_unlock_spec.rb
@@ -32,5 +32,9 @@ RSpec.describe DoctrineUnlock, type: :model do
   describe 'associations' do
     it { should belong_to(:doctrine) }
     it { should belong_to(:unlock) }
+    it { should have_one(:restriction) }
+    it { should have_many(:restriction_units) }
+    it { should have_many(:restriction_upgrades) }
+    it { should have_many(:restriction_offmaps) }
   end
 end

--- a/spec/models/enabled_unit_spec.rb
+++ b/spec/models/enabled_unit_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe EnabledUnit, type: :model do
   end
 
 
-  it "generates and saves the description" do
+  it "generates and saves the internal_description" do
     unit = create :infantry, display_name: "Rifles"
     restriction = create :restriction, name: "American army"
     ruleset = create :ruleset
     enabled_unit = create :enabled_unit, restriction: restriction, unit: unit, ruleset: ruleset
-    expect(enabled_unit.description).to eq("American army - Rifles")
+    expect(enabled_unit.internal_description).to eq("American army - Rifles")
   end
 end
 

--- a/spec/models/enabled_upgrade_spec.rb
+++ b/spec/models/enabled_upgrade_spec.rb
@@ -2,20 +2,20 @@
 #
 # Table name: restriction_upgrades
 #
-#  id                                                    :bigint           not null, primary key
-#  description(What does this RestrictionUpgrade do?)    :string
-#  fuel(Fuel cost)                                       :integer
-#  man(Manpower cost)                                    :integer
-#  mun(Munition cost)                                    :integer
-#  pop(Population cost)                                  :integer
-#  priority(Priority of this restriction)                :integer
-#  type(What effect this restriction has on the upgrade) :string           not null
-#  uses(Number of uses this upgrade provides)            :integer
-#  created_at                                            :datetime         not null
-#  updated_at                                            :datetime         not null
-#  restriction_id                                        :bigint
-#  ruleset_id                                            :bigint
-#  upgrade_id                                            :bigint
+#  id                                                          :bigint           not null, primary key
+#  fuel(Fuel cost)                                             :integer
+#  internal_description(What does this RestrictionUpgrade do?) :string
+#  man(Manpower cost)                                          :integer
+#  mun(Munition cost)                                          :integer
+#  pop(Population cost)                                        :integer
+#  priority(Priority of this restriction)                      :integer
+#  type(What effect this restriction has on the upgrade)       :string           not null
+#  uses(Number of uses this upgrade provides)                  :integer
+#  created_at                                                  :datetime         not null
+#  updated_at                                                  :datetime         not null
+#  restriction_id                                              :bigint
+#  ruleset_id                                                  :bigint
+#  upgrade_id                                                  :bigint
 #
 # Indexes
 #
@@ -42,12 +42,12 @@ RSpec.describe EnabledUpgrade, type: :model do
   end
 
 
-  it "generates and saves the description" do
+  it "generates and saves the internal_description" do
     upgrade = create :upgrade, display_name: "Medkit"
     restriction = create :restriction, name: "American army"
     ruleset = create :ruleset
     enabled_upgrade = create :enabled_upgrade, restriction: restriction, upgrade: upgrade, ruleset: ruleset
-    expect(enabled_upgrade.description).to eq("American army - Medkit")
+    expect(enabled_upgrade.internal_description).to eq("American army - Medkit")
   end
 end
 

--- a/spec/models/faction_spec.rb
+++ b/spec/models/faction_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Faction, type: :model do
 
   describe 'associations' do
     it { should have_many(:doctrines) }
-    it { should have_one(:restrictions) }
+    it { should have_one(:restriction) }
   end
 
   describe 'validations' do

--- a/spec/models/faction_spec.rb
+++ b/spec/models/faction_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Faction, type: :model do
 
   describe 'associations' do
     it { should have_many(:doctrines) }
-    it { should have_many(:restrictions) }
+    it { should have_one(:restrictions) }
   end
 
   describe 'validations' do

--- a/spec/models/restriction_spec.rb
+++ b/spec/models/restriction_spec.rb
@@ -15,6 +15,7 @@
 #
 # Indexes
 #
+#  idx_restrictions_uniq_id                  (faction_id,doctrine_id,doctrine_unlock_id,unlock_id) UNIQUE
 #  index_restrictions_on_doctrine_id         (doctrine_id)
 #  index_restrictions_on_doctrine_unlock_id  (doctrine_unlock_id)
 #  index_restrictions_on_faction_id          (faction_id)
@@ -30,7 +31,7 @@
 require "rails_helper"
 
 RSpec.describe Restriction, type: :model do
-  let!(:restriction) { create :restriction}
+  let!(:restriction) { create :restriction }
 
   describe 'associations' do
     it { should belong_to(:faction).optional }
@@ -73,6 +74,65 @@ RSpec.describe Restriction, type: :model do
     it "is invalid to have both doctrine and unlock" do
       restriction = Restriction.new(name: "name", doctrine: doctrine, unlock: unlock)
       expect(restriction).not_to be_valid
+    end
+  end
+
+  context "traits" do
+    context "default" do
+      it "has non-null faction" do
+        expect(restriction.faction.present?).to be true
+        expect(restriction.doctrine.present?).to be false
+        expect(restriction.doctrine_unlock.present?).to be false
+        expect(restriction.unlock.present?).to be false
+      end
+    end
+
+    context "with_doctrine" do
+      let!(:doctrine) { create :doctrine }
+      let!(:restriction) { create :restriction, :with_doctrine, doctrine: doctrine }
+
+      it "has non-null doctrine" do
+        expect(restriction.faction.present?).to be false
+        expect(restriction.doctrine.present?).to be true
+        expect(restriction.doctrine_unlock.present?).to be false
+        expect(restriction.unlock.present?).to be false
+      end
+
+      it "has the specified doctrine" do
+        expect(restriction.doctrine).to eq doctrine
+      end
+    end
+
+    context "with_doctrine_unlock" do
+      let!(:doctrine_unlock) { create :doctrine_unlock }
+      let!(:restriction) { create :restriction, :with_doctrine_unlock, doctrine_unlock: doctrine_unlock }
+
+      it "has non-null doctrine_unlock" do
+        expect(restriction.faction.present?).to be false
+        expect(restriction.doctrine.present?).to be false
+        expect(restriction.doctrine_unlock.present?).to be true
+        expect(restriction.unlock.present?).to be false
+      end
+
+      it "has the specified doctrine_unlock" do
+        expect(restriction.doctrine_unlock).to eq doctrine_unlock
+      end
+    end
+
+    context "with_unlock" do
+      let!(:unlock) { create :unlock }
+      let!(:restriction) { create :restriction, :with_unlock, unlock: unlock }
+
+      it "has non-null unlock" do
+        expect(restriction.faction.present?).to be false
+        expect(restriction.doctrine.present?).to be false
+        expect(restriction.doctrine_unlock.present?).to be false
+        expect(restriction.unlock.present?).to be true
+      end
+
+      it "has the specified unlock" do
+        expect(restriction.unlock).to eq unlock
+      end
     end
   end
 end

--- a/spec/models/restriction_upgrade_spec.rb
+++ b/spec/models/restriction_upgrade_spec.rb
@@ -2,19 +2,20 @@
 #
 # Table name: restriction_upgrades
 #
-#  id                                                    :bigint           not null, primary key
-#  fuel(Fuel cost)                                       :integer
-#  man(Manpower cost)                                    :integer
-#  mun(Munition cost)                                    :integer
-#  pop(Population cost)                                  :integer
-#  priority(Priority of this restriction)                :integer
-#  type(What effect this restriction has on the upgrade) :string           not null
-#  uses(Number of uses this upgrade provides)            :integer
-#  created_at                                            :datetime         not null
-#  updated_at                                            :datetime         not null
-#  restriction_id                                        :bigint
-#  ruleset_id                                            :bigint
-#  upgrade_id                                            :bigint
+#  id                                                          :bigint           not null, primary key
+#  fuel(Fuel cost)                                             :integer
+#  internal_description(What does this RestrictionUpgrade do?) :string
+#  man(Manpower cost)                                          :integer
+#  mun(Munition cost)                                          :integer
+#  pop(Population cost)                                        :integer
+#  priority(Priority of this restriction)                      :integer
+#  type(What effect this restriction has on the upgrade)       :string           not null
+#  uses(Number of uses this upgrade provides)                  :integer
+#  created_at                                                  :datetime         not null
+#  updated_at                                                  :datetime         not null
+#  restriction_id                                              :bigint
+#  ruleset_id                                                  :bigint
+#  upgrade_id                                                  :bigint
 #
 # Indexes
 #

--- a/spec/models/unit_swap_spec.rb
+++ b/spec/models/unit_swap_spec.rb
@@ -2,13 +2,13 @@
 #
 # Table name: unit_swaps
 #
-#  id                                        :bigint           not null, primary key
-#  description(Description of this UnitSwap) :string
-#  created_at                                :datetime         not null
-#  updated_at                                :datetime         not null
-#  new_unit_id                               :bigint           not null
-#  old_unit_id                               :bigint           not null
-#  unlock_id                                 :bigint           not null
+#  id                                                          :bigint           not null, primary key
+#  internal_description(Internal description of this UnitSwap) :string
+#  created_at                                                  :datetime         not null
+#  updated_at                                                  :datetime         not null
+#  new_unit_id                                                 :bigint           not null
+#  old_unit_id                                                 :bigint           not null
+#  unlock_id                                                   :bigint           not null
 #
 # Indexes
 #
@@ -34,8 +34,8 @@ RSpec.describe UnitSwap, type: :model do
     it { should belong_to(:new_unit) }
   end
 
-  it "should construct a description" do
-    expect(unit_swap.description)
+  it "should construct a internal_description" do
+    expect(unit_swap.internal_description)
       .to eq "#{unit_swap.unlock.display_name} | #{unit_swap.old_unit.display_name} -> #{unit_swap.new_unit.display_name}"
   end
 end

--- a/spec/models/unit_swap_spec.rb
+++ b/spec/models/unit_swap_spec.rb
@@ -12,9 +12,10 @@
 #
 # Indexes
 #
-#  index_unit_swaps_on_new_unit_id  (new_unit_id)
-#  index_unit_swaps_on_old_unit_id  (old_unit_id)
-#  index_unit_swaps_on_unlock_id    (unlock_id)
+#  index_unit_swaps_on_new_unit_id                (new_unit_id)
+#  index_unit_swaps_on_old_unit_id                (old_unit_id)
+#  index_unit_swaps_on_unlock_id                  (unlock_id)
+#  index_unit_swaps_on_unlock_id_and_old_unit_id  (unlock_id,old_unit_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/models/unlock_spec.rb
+++ b/spec/models/unlock_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe Unlock, type: :model do
   describe 'associations' do
     it { should have_many(:doctrine_unlocks) }
     it { should have_many(:doctrines) }
-    it { should have_many(:restrictions) }
+    it { should have_one(:restriction) }
+    it { should have_many(:restriction_units) }
+    it { should have_many(:restriction_upgrades) }
+    it { should have_many(:restriction_offmaps) }
   end
 end

--- a/spec/models/unlock_spec.rb
+++ b/spec/models/unlock_spec.rb
@@ -15,28 +15,14 @@
 #
 #  index_unlocks_on_name  (name) UNIQUE
 #
-class Unlock < ApplicationRecord
-  has_many :doctrine_unlocks
-  has_many :doctrines, through: :doctrine_unlocks
-  has_one :restriction
+require "rails_helper"
 
-  has_many :restriction_units
-  has_many :restriction_upgrades
-  has_many :restriction_offmaps
+RSpec.describe Unlock, type: :model do
+  let!(:unit_swap) { create :unit_swap}
 
-  validates_presence_of :name
-  validates_presence_of :display_name
-  validates_uniqueness_of :name
-
-  def entity
-    Entity.new(self)
-  end
-
-  class Entity < Grape::Entity
-    expose :id
-    expose :name
-    expose :display_name, as: :displayName
-    expose :description
-    expose :image_path, as: :imagePath
+  describe 'associations' do
+    it { should have_many(:doctrine_unlocks) }
+    it { should have_many(:doctrines) }
+    it { should have_many(:restrictions) }
   end
 end

--- a/spec/services/company_unlock_service_spec.rb
+++ b/spec/services/company_unlock_service_spec.rb
@@ -1,0 +1,278 @@
+require "rails_helper"
+
+RSpec.describe CompanyUnlockService do
+  let!(:ruleset) { create :ruleset }
+  let!(:doctrine) { create :doctrine }
+  let(:vps_current) { 10 }
+  let!(:company) { create :company, doctrine: doctrine, vps_current: vps_current }
+  let!(:unlock1) { create :unlock }
+  let(:vp_cost) { 3 }
+  let!(:doctrine_unlock) { create :doctrine_unlock, doctrine: doctrine, unlock: unlock1, vp_cost: vp_cost }
+  let!(:du_restriction) { create :restriction, :with_doctrine_unlock, doctrine_unlock: doctrine_unlock }
+  let!(:unit1) { create :unit }
+  let!(:unit2) { create :unit }
+  let!(:unit3) { create :unit }
+  let!(:default_available) { 10 }
+  let!(:new_unit_available) { 4 }
+  let(:man) { 250 }
+  let(:resupply_max) { 10 }
+
+  subject(:instance) { described_class.new(company) }
+
+  describe "#purchase_doctrine_unlock" do
+    subject { instance.purchase_doctrine_unlock(doctrine_unlock) }
+
+    context "when units are enabled for the company only" do
+      let!(:du_enabled_unit) { create :enabled_unit, restriction: du_restriction, unit: unit1, ruleset: ruleset,
+                                      man: man, resupply_max: resupply_max }
+
+      it "creates an available_unit for the enabled unit" do
+        expect { subject }.to change { AvailableUnit.count }.by 1
+        new_au = AvailableUnit.last
+        expect(new_au.unit_id).to eq unit1.id
+        expect(new_au.man).to eq man
+        expect(new_au.resupply_max).to eq resupply_max
+      end
+
+      it "doesn't recalculate resources" do
+        company_service_double = double
+        allow(CompanyService).to receive(:new).and_return company_service_double
+        expect(company_service_double).not_to receive(:recalculate_resources)
+        subject
+      end
+
+      it "pays for the company unlock" do
+        subject
+        expect(company.reload.vps_current).to eq vps_current - vp_cost
+      end
+    end
+
+    context "when units are disabled for the company only" do
+      let!(:du_disabled_unit) { create :disabled_unit, restriction: du_restriction, unit: unit1, ruleset: ruleset,
+                                       man: man, resupply_max: resupply_max }
+      let!(:au1) { create :base_available_unit, company: company, unit: unit1 }
+      let!(:au2) { create :base_available_unit, company: company, unit: unit2 }
+      let!(:squad1) { create :squad, company: company, available_unit: au1 }
+      let!(:squad2) { create :squad, company: company, available_unit: au1 }
+      let!(:squad3) { create :squad, company: company, available_unit: au2 }
+
+      it "removes the available_unit for the disabled unit" do
+        expect { subject }.to change { AvailableUnit.count }.by -1
+        expect(AvailableUnit.exists?(au1.id)).to be false
+        expect(au2.destroyed?).to be false
+      end
+
+      it "removes squads associated with the disabled unit" do
+        expect { subject }.to change { Squad.count }.by -2
+        expect(Squad.exists?(squad1.id)).to be false
+        expect(Squad.exists?(squad2.id)).to be false
+        expect(Squad.exists?(squad3.id)).to be true
+      end
+
+      it "recalculates resources" do
+        company_service_double = double
+        allow(CompanyService).to receive(:new).and_return company_service_double
+        expect(company_service_double).to receive(:recalculate_resources)
+        subject
+      end
+
+      it "pays for the company unlock" do
+        subject
+        expect(company.reload.vps_current).to eq vps_current - vp_cost
+      end
+    end
+
+    context "when units are enabled/disabled and swapped" do
+      let!(:du_enabled_unit) { create :enabled_unit, restriction: du_restriction, unit: unit3, ruleset: ruleset,
+                                      man: man, resupply_max: new_unit_available }
+      let!(:du_disabled_unit) { create :disabled_unit, restriction: du_restriction, unit: unit1, ruleset: ruleset }
+      let!(:au1) { create :base_available_unit, company: company, unit: unit1, available: default_available }
+      let!(:au2) { create :base_available_unit, company: company, unit: unit2, available: default_available }
+      let!(:unit_swap) { create :unit_swap, unlock: unlock1, old_unit: unit1, new_unit: unit3 }
+      let!(:squad1) { create :squad, company: company, available_unit: au1 }
+      let!(:squad2) { create :squad, company: company, available_unit: au1 }
+      let!(:squad3) { create :squad, company: company, available_unit: au2 }
+      let!(:squad4) { create :squad, company: company, available_unit: au2 }
+
+      it "creates an available_unit for the enabled unit" do
+        subject
+        new_au = AvailableUnit.last
+        expect(new_au.unit_id).to eq unit3.id
+        expect(new_au.man).to eq man
+        expect(new_au.resupply_max).to eq new_unit_available
+      end
+
+      it "removes the available_unit for the disabled unit" do
+        subject
+        expect(AvailableUnit.exists?(au1.id)).to be false
+        expect(au2.destroyed?).to be false
+      end
+
+      it "updates squads containing the old unit" do
+        subject
+        new_au = AvailableUnit.last
+        expect(squad1.reload.available_unit).to eq new_au
+        expect(squad2.reload.available_unit).to eq new_au
+        expect(squad3.reload.available_unit).to eq au2
+        expect(squad4.reload.available_unit).to eq au2
+      end
+
+      it "updates the new unit's available value" do
+        subject
+        new_au = AvailableUnit.last
+        expect(au2.reload.available).to eq default_available
+        expect(new_au.reload.available).to eq new_unit_available - 2
+      end
+
+      it "recalculates resources" do
+        company_service_double = double
+        allow(CompanyService).to receive(:new).and_return company_service_double
+        expect(company_service_double).to receive(:recalculate_resources)
+        subject
+      end
+
+      it "pays for the company unlock" do
+        subject
+        expect(company.reload.vps_current).to eq vps_current - vp_cost
+      end
+    end
+
+    it "fails when the company does not have the matching doctrine for the given doctrine_unlock" do
+      new_doctrine = create :doctrine
+      company.update!(doctrine: new_doctrine)
+      expect { instance.purchase_doctrine_unlock(doctrine_unlock) }.
+        to raise_error "Company #{company.id} has doctrine #{new_doctrine.name} but doctrine unlock #{doctrine_unlock.id} belongs to doctrine #{doctrine.name}"
+    end
+
+    context "when vps_current is too low" do
+      let(:vps_current) { 2 }
+
+      it "fails when the company does not have sufficient vps_current to purchase the doctrine_unlock" do
+        expect { instance.purchase_doctrine_unlock(doctrine_unlock) }.
+          to raise_error "Company #{company.id} has insufficient VPs to purchase doctrine unlock #{doctrine_unlock.id}, have #{vps_current} need #{vp_cost}"
+      end
+    end
+
+    it "fails when the company already has a company_unlock for the given doctrine_unlock" do
+      create :company_unlock, company: company, doctrine_unlock: doctrine_unlock
+      expect { instance.purchase_doctrine_unlock(doctrine_unlock) }.
+        to raise_error "Company #{company.id} already owns doctrine unlock #{doctrine_unlock.id}"
+    end
+  end
+
+  describe "#swap_squad_units" do
+    let!(:au1) { create :base_available_unit, company: company, unit: unit1, available: default_available }
+    let!(:au2) { create :base_available_unit, company: company, unit: unit2, available: default_available }
+    let!(:au3) { create :base_available_unit, company: company, unit: unit3, available: new_unit_available }
+    let!(:unit_swap) { create :unit_swap, unlock: unlock1, old_unit: unit1, new_unit: unit3 }
+
+    context "when there are squads containing old units" do
+      let!(:squad1) { create :squad, company: company, available_unit: au1 }
+      let!(:squad2) { create :squad, company: company, available_unit: au1 }
+      let!(:squad3) { create :squad, company: company, available_unit: au2 }
+      let!(:squad4) { create :squad, company: company, available_unit: au2 }
+
+      it "updates squads containing the old unit" do
+        instance.send(:swap_squad_units, [squad1, squad2, squad3, squad4], [unit_swap])
+        expect(squad1.reload.available_unit).to eq au3
+        expect(squad2.reload.available_unit).to eq au3
+        expect(squad3.reload.available_unit).to eq au2
+        expect(squad4.reload.available_unit).to eq au2
+      end
+
+      it "updates the new unit's available value" do
+        instance.send(:swap_squad_units, [squad1, squad2, squad3, squad4], [unit_swap])
+        expect(au1.reload.available).to eq default_available
+        expect(au2.reload.available).to eq default_available
+        expect(au3.reload.available).to eq 2
+      end
+    end
+
+    context "when there are no squads containing old units" do
+      let!(:squad3) { create :squad, company: company, available_unit: au2 }
+      let!(:squad4) { create :squad, company: company, available_unit: au2 }
+
+      it "does not change the existing squads" do
+        instance.send(:swap_squad_units, [squad3, squad4], [unit_swap])
+        expect(squad3.reload.available_unit).to eq au2
+        expect(squad4.reload.available_unit).to eq au2
+      end
+
+      it "does not change the new unit's available value" do
+        instance.send(:swap_squad_units, [squad3, squad4], [unit_swap])
+        expect(au1.reload.available).to eq default_available
+        expect(au2.reload.available).to eq default_available
+        expect(au3.reload.available).to eq new_unit_available
+      end
+    end
+
+    context "when the new unit to swap to is not available for the company" do
+      let!(:au3) { nil }
+      let!(:squad1) { create :squad, company: company, available_unit: au1 }
+      let!(:squad2) { create :squad, company: company, available_unit: au1 }
+      let!(:squad3) { create :squad, company: company, available_unit: au2 }
+      let!(:squad4) { create :squad, company: company, available_unit: au2 }
+
+      it "does not update squads containing the old unit" do
+        instance.send(:swap_squad_units, [squad1, squad2, squad3, squad4], [unit_swap])
+        expect(squad1.reload.available_unit).to eq au1
+        expect(squad2.reload.available_unit).to eq au1
+        expect(squad3.reload.available_unit).to eq au2
+        expect(squad4.reload.available_unit).to eq au2
+      end
+    end
+  end
+
+  describe "#pay_for_company_unlock" do
+    it "creates a CompanyUnlock for the Company and DoctrineUnlock" do
+      expect { instance.send(:pay_for_company_unlock, doctrine_unlock) }.to change { CompanyUnlock.count }.by 1
+      expect(company.company_unlocks.size).to eq 1
+      expect(company.company_unlocks.first.doctrine_unlock).to eq doctrine_unlock
+    end
+
+    it "updates the Company's vps_current to pay for the DoctrineUnlock" do
+      instance.send(:pay_for_company_unlock, doctrine_unlock)
+      expect(company.reload.vps_current).to eq vps_current - vp_cost
+    end
+  end
+
+  describe "#validate_correct_doctrine" do
+    it "passes when the company has the matching doctrine for the given doctrine_unlock" do
+      expect { instance.send(:validate_correct_doctrine, doctrine_unlock) }.not_to raise_error
+    end
+
+    it "fails when the company does not have the matching doctrine for the given doctrine_unlock" do
+      new_doctrine = create :doctrine
+      company.update!(doctrine: new_doctrine)
+      expect { instance.send(:validate_correct_doctrine, doctrine_unlock) }.
+        to raise_error "Company #{company.id} has doctrine #{new_doctrine.name} but doctrine unlock #{doctrine_unlock.id} belongs to doctrine #{doctrine.name}"
+    end
+  end
+
+  describe "#validate_sufficient_vps" do
+    it "passes when the company has sufficient vps_current to purchase the doctrine_unlock" do
+      expect { instance.send(:validate_sufficient_vps, doctrine_unlock) }.not_to raise_error
+    end
+
+    context "when vps_current is too low" do
+      let(:vps_current) { 2 }
+
+      it "fails when the company does not have sufficient vps_current to purchase the doctrine_unlock" do
+        expect { instance.send(:validate_sufficient_vps, doctrine_unlock) }.
+          to raise_error "Company #{company.id} has insufficient VPs to purchase doctrine unlock #{doctrine_unlock.id}, have #{vps_current} need #{vp_cost}"
+      end
+    end
+  end
+
+  describe "#validate_unpurchased" do
+    it "passes when the company does not have a company_unlock for the given doctrine_unlock" do
+      expect { instance.send(:validate_unpurchased, doctrine_unlock) }.not_to raise_error
+    end
+
+    it "fails when the company already has a company_unlock for the given doctrine_unlock" do
+      create :company_unlock, company: company, doctrine_unlock: doctrine_unlock
+      expect { instance.send(:validate_unpurchased, doctrine_unlock) }.
+        to raise_error "Company #{company.id} already owns doctrine unlock #{doctrine_unlock.id}"
+    end
+  end
+end


### PR DESCRIPTION
CompanyUnlock service to handle purchasing doctrine unlocks for a company

To support unit swapping, need to change squads' `available_unit` attribute to point to the new available_unit for the new unit. This requires differentiating `AvailableUnit` by type so that we only use `BaseAvailableUnit`, representing the primary purchasable version of the unit (as opposed to free or other special cases), to swap to.

Since now it's possible to have multiple `AvailableUnit`s for a company and Unit, company squad updates need to pass `available_unit_id` as the identifier of what was purchased as `unit_id` will not be sufficiently specific.