### PR TITLE
Squad pop with transported

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -43,3 +43,7 @@ Follow the Unit model, where
 `CallinModifierAllowedUnit` defines all units that may be in the platoon and still qualify for the callin modifier. 
 * If there are non-zero `CallinModifierAllowedUnit`s, only those units may exist in the platoon and qualify
 * If there are zero `CallinModifierAllowedUnit`s, any unit may exist in the platoon and qualify
+
+## Squad Upgrades
+1. `Squad` model has a `pop` attribute encompassing both the unit's pop and any squad upgrades with pop
+2. UI will update this pop value for the user's convenience during company construction, but the backend will recalculate the squad pop value before saving

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,3 @@
-Upgrades:
-1. Upgrades that increase squad pop or model count aren't updating the platoon's count. Similar for removing the upgrade
-
-
 SquadBuilder
 1. Fix company grid highlighting for transport squads when dragging
 2. Fix double tooltips appearing when hovering over transported squad card

--- a/app/javascript/features/companies/manage/SquadBuilder.jsx
+++ b/app/javascript/features/companies/manage/SquadBuilder.jsx
@@ -112,23 +112,23 @@ export const SquadBuilder = ({}) => {
 
   const onTabChange = (newTab) => {
     setCurrentTab(newTab)
-    dispatch(setSelectedAvailableUnitId(null))
     dispatch(setSelectedSquadAccess({ tab: null, index: null, uuid: null, transportUuid: null }))
+    dispatch(setSelectedAvailableUnitId(null))
   }
 
   const onUnitSelect = (availableUnitId) => {
     /** Called when a unit is selected. Populates the unit stats box with relevant data
      */
-    dispatch(setSelectedAvailableUnitId(availableUnitId))
     dispatch(setSelectedSquadAccess({ tab: null, index: null, uuid: null, transportUuid: null }))
+    dispatch(setSelectedAvailableUnitId(availableUnitId))
   }
 
   const onSquadSelect = (availableUnitId, tab, index, uuid, transportUuid) => {
     /** Called when a squad is selected. Populates the unit stats box with relevant data
      * TODO if a squad is clicked, should take upgrades into account
      */
-    dispatch(setSelectedAvailableUnitId(availableUnitId))
     dispatch(setSelectedSquadAccess({ tab, index, uuid, transportUuid }))
+    dispatch(setSelectedAvailableUnitId(availableUnitId))
   }
 
   /** For a new non-transported squad, use the availableUnit and unit to construct a new squad object

--- a/app/javascript/features/companies/manage/available_upgrades/AvailableUpgradeClickable.jsx
+++ b/app/javascript/features/companies/manage/available_upgrades/AvailableUpgradeClickable.jsx
@@ -1,15 +1,15 @@
 import React from 'react'
-import { useSelector } from "react-redux";
-import { Box, Tooltip } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import {useSelector} from "react-redux";
+import {Box, Tooltip} from "@mui/material";
+import {makeStyles} from "@mui/styles";
 
-import { selectAvailableUpgradeById } from "./availableUpgradesSlice";
-import { AvailableUpgradeTooltipContent } from "./AvailableUpgradeTooltipContent";
-import { UpgradeIcon } from "../upgrades/UpgradeIcon";
-import { selectUpgradeById } from "../upgrades/upgradesSlice";
-import { selectSelectedSquad } from "../units/squadsSlice";
-import { selectUnitById } from "../units/unitsSlice";
-import { selectSquadUpgradesForSquad } from "../squad_upgrades/squadUpgradesSlice";
+import {selectAvailableUpgradeById} from "./availableUpgradesSlice";
+import {AvailableUpgradeTooltipContent} from "./AvailableUpgradeTooltipContent";
+import {UpgradeIcon} from "../upgrades/UpgradeIcon";
+import {selectUpgradeById} from "../upgrades/upgradesSlice";
+import {selectSelectedSquad, selectSquadInTabIndexUuid} from "../units/squadsSlice";
+import {selectUnitById} from "../units/unitsSlice";
+import {selectSquadUpgradesForSquad} from "../squad_upgrades/squadUpgradesSlice";
 
 const sumSlotsAndExistingUses = (squadUpgrades, upgrade) => {
   let slotsUsed = 0,
@@ -23,41 +23,52 @@ const sumSlotsAndExistingUses = (squadUpgrades, upgrade) => {
       squadExistingCount += 1
     }
   })
-  return { slotsUsed, unitwideSlotsUsed, squadExistingCount }
+  return {slotsUsed, unitwideSlotsUsed, squadExistingCount}
 }
 
 // TODO this is getting called multiple times on purchase and for each available upgrade clickable. can we make this more perf?
-const calculateDisabled = (enabled, selectedUnit, availableUpgrade, upgrade, selectedSquad, squadUpgrades) => {
-  let disabled = true
+const calculateDisabled = (enabled, selectedUnit, availableUpgrade, upgrade, selectedSquad, squadUpgrades, transportSquad) => {
   if (enabled && !_.isNil(selectedUnit)) {
-    const { slotsUsed, unitwideSlotsUsed, squadExistingCount } = sumSlotsAndExistingUses(squadUpgrades, upgrade)
+    const {slotsUsed, unitwideSlotsUsed, squadExistingCount} = sumSlotsAndExistingUses(squadUpgrades, upgrade)
 
     if (!_.isNil(availableUpgrade.max) && availableUpgrade.max <= squadExistingCount) {
       // At or exceeded max number of this upgrade that the squad can have
       return true
-    } else if (upgrade.upgradeSlots > 0) {
+    }
+    if (upgrade.upgradeSlots > 0) {
       // Calc upgrade slots/unitwide slots against squad's unit's slots/unitwide slots
       const availableSlots = selectedUnit?.upgradeSlots - slotsUsed
-      if (upgrade.upgradeSlots <= availableSlots) {
-        // We have enough slots to fit this upgrade that uses slots
-        return false
+      if (upgrade.upgradeSlots > availableSlots) {
+        // We don't have enough slots to fit this upgrade that uses slots
+        return true
       }
-    } else if (upgrade.unitwideUpgradeSlots > 0) {
-      const availableUnitwideSlots = selectedUnit?.unitwideUpgradeSlots - unitwideSlotsUsed
-      if (upgrade.unitwideUpgradeSlots <= availableUnitwideSlots) {
-        // We have enough unitwide slots to fit this upgrade that uses unitwide slots
-        return false
-      }
-    } else {
-      // At this stage, we know
-      // 1. Not at max for the squad for this upgrade
-      // 2. Doesn't use upgrade slots
-      // 3. Doesn't use unitwide upgrade slots
-      // Allow the upgrade (may still not have the resources but we don't care about that here)
-      return false
     }
+    if (upgrade.unitwideUpgradeSlots > 0) {
+      const availableUnitwideSlots = selectedUnit?.unitwideUpgradeSlots - unitwideSlotsUsed
+      if (upgrade.unitwideUpgradeSlots > availableUnitwideSlots) {
+        // We don't have enough unitwide slots to fit this upgrade that uses unitwide slots
+        return true
+      }
+    }
+
+    if (transportSquad) {
+      // If transport exists, check that there is space for the model slots of the upgrade
+      const availableTransportModelSlots = transportSquad.transportModelSlots - transportSquad.usedModelSlots
+      if (!_.isNil(upgrade.additionalModelCount) && upgrade.additionalModelCount > availableTransportModelSlots) {
+        // We don't have enough transport model slots to fit this upgrade that increases model count
+        return true
+      }
+    }
+
+    // At this stage, we know
+    // 1. Not at max for the squad for this upgrade
+    // 2. Doesn't exceed upgrade slots
+    // 3. Doesn't exceed unitwide upgrade slots
+    // 4. Doesn't exceed transport total model slots
+    // Allow the upgrade (may still not have the resources but we don't care about that here)
+    return false
   }
-  return disabled
+  return true
 }
 
 const useStyles = makeStyles(() => ({
@@ -69,18 +80,19 @@ const useStyles = makeStyles(() => ({
     cursor: 'pointer'
   }
 }))
-export const AvailableUpgradeClickable = ({ availableUpgradeId, onUpgradeClick, enabled }) => {
+export const AvailableUpgradeClickable = ({availableUpgradeId, onUpgradeClick, enabled}) => {
   const classes = useStyles()
   const availableUpgrade = useSelector(state => selectAvailableUpgradeById(state, availableUpgradeId))
   const upgrade = useSelector(state => selectUpgradeById(state, availableUpgrade?.upgradeId))
 
   // Need the squad to determine if purchased this upgrade
   const selectedSquad = useSelector(selectSelectedSquad)
+  const transportSquad = useSelector(state => selectSquadInTabIndexUuid(state, selectedSquad?.tab, selectedSquad?.index, selectedSquad?.transportUuid))
   // Need the unit to determine if squad has slots for the upgrade
   const selectedUnit = useSelector(state => selectUnitById(state, selectedSquad?.unitId))
   const squadUpgrades = useSelector(state => selectSquadUpgradesForSquad(state, selectedSquad?.tab, selectedSquad?.index, selectedSquad?.uuid))
 
-  const disabled = calculateDisabled(enabled, selectedUnit, availableUpgrade, upgrade, selectedSquad, squadUpgrades)
+  const disabled = calculateDisabled(enabled, selectedUnit, availableUpgrade, upgrade, selectedSquad, squadUpgrades, transportSquad)
 
   const onUpgradeBoxClick = () => {
     if (!disabled) {

--- a/app/javascript/features/companies/manage/squad_upgrades/squadUpgradesSlice.jsx
+++ b/app/javascript/features/companies/manage/squad_upgrades/squadUpgradesSlice.jsx
@@ -70,11 +70,15 @@ const squadUpgradesSlice = createSlice({
       .addCase(removeSquad, (state, action) => {
         const { uuid, index, tab } = action.payload
 
+        if (!state.currentSquadUpgrades?.[tab]?.[index]?.[uuid]) return
+
         delete state.currentSquadUpgrades[tab][index][uuid]
         state.isChanged = true
       })
       .addCase(removeTransportedSquad, (state, action) => {
         const { uuid, index, tab } = action.payload
+
+        if (!state.currentSquadUpgrades?.[tab]?.[index]?.[uuid]) return
 
         delete state.currentSquadUpgrades[tab][index][uuid]
         state.isChanged = true

--- a/app/javascript/features/companies/manage/squads/CompanyGridDropTarget.jsx
+++ b/app/javascript/features/companies/manage/squads/CompanyGridDropTarget.jsx
@@ -107,8 +107,8 @@ export const CompanyGridDropTarget = ({
     onSquadMove(squad, unit, gridIndex, currentTab)
   }
 
-  const onDestroyClick = (squad, transportUuid = null) => {
-    onSquadDestroy(squad, transportUuid)
+  const onDestroyClick = (squad, squadUpgrades, transportUuid = null) => {
+    onSquadDestroy(squad, squadUpgrades, transportUuid)
   }
 
   const insertSquadUnitIds = (unitIds, squad) => {

--- a/app/javascript/features/companies/manage/squads/CompanyGridDropTarget.jsx
+++ b/app/javascript/features/companies/manage/squads/CompanyGridDropTarget.jsx
@@ -127,7 +127,7 @@ export const CompanyGridDropTarget = ({
   if (squads) {
     for (const squad of Object.values(squads)) {
       insertSquadUnitIds(unitIds, squad)
-      gridPop += parseFloat(squad.combinedPop) // Use combinedPop to include transported squads' pop
+      gridPop += parseFloat(squad.popWithTransported) // Use popWithTransported to include transported squads' pop
       squadCards.push(<SquadCard key={squad.uuid}
                                  uuid={squad.uuid}
                                  index={gridIndex} tab={currentTab}

--- a/app/javascript/features/companies/manage/units/squad.js
+++ b/app/javascript/features/companies/manage/units/squad.js
@@ -27,8 +27,8 @@ export const createSquad = (availableUnit,
     unitName: unit.name,
     unitDisplayName: unit.displayName,
     unitType: unit.type,
-    pop: parseFloat(availableUnit.pop),
-    combinedPop: parseFloat(availableUnit.pop), // Combination of transport's pop and passenger pops
+    pop: parseFloat(availableUnit.pop), // Squad pop = unit pop + upgrades pop
+    popWithTransported: parseFloat(availableUnit.pop), // Combination of transport's pop and passenger pops
     man: availableUnit.man,
     mun: availableUnit.mun,
     fuel: availableUnit.fuel,
@@ -59,7 +59,7 @@ export const loadSquad = (squad) => {
     unitDisplayName: squad.unitDisplayName,
     unitType: squad.unitType,
     pop: parseFloat(squad.pop),
-    combinedPop: parseFloat(squad.pop),
+    popWithTransported: parseFloat(squad.pop),
     man: squad.man,
     mun: squad.mun,
     fuel: squad.fuel,

--- a/app/javascript/features/companies/manage/units/squadsSlice.js
+++ b/app/javascript/features/companies/manage/units/squadsSlice.js
@@ -137,12 +137,12 @@ const buildNewSquadTabs = (squads) => {
     transportedSquads.forEach(squad => {
       const transport = tabs[squad.tab][squad.index][squad.transportUuid]
       const transportedSquads = { ...transport.transportedSquads, [squad.uuid]: loadSquad(squad) }
-      const combinedPop = transport.combinedPop + parseFloat(squad.pop)
+      const popWithTransported = transport.popWithTransported + parseFloat(squad.pop)
       const usedSquadSlots = transport.usedSquadSlots + 1
       const usedModelSlots = transport.usedModelSlots + squad.totalModelCount
       tabs[squad.tab][squad.index][squad.transportUuid] = {
         ...transport,
-        combinedPop: combinedPop,
+        popWithTransported: popWithTransported,
         transportedSquads: transportedSquads,
         usedSquadSlots: usedSquadSlots,
         usedModelSlots: usedModelSlots
@@ -190,7 +190,7 @@ const squadsSlice = createSlice({
             transport.transportedSquads = transportedSquads
             transport.usedSquadSlots = usedSquadSlots + 1
             transport.usedModelSlots = usedModelSlots + totalModelCount
-            transport.combinedPop = parseFloat(transport.combinedPop) + parseFloat(pop)
+            transport.popWithTransported = parseFloat(transport.popWithTransported) + parseFloat(pop)
           } else {
             // Otherwise, add the squad to the platoon
             if (!Object.keys(platoon).includes(uuid)) {
@@ -224,7 +224,7 @@ const squadsSlice = createSlice({
       if (_.has(platoon, transportUuid)) {
         const transport = platoon[transportUuid]
         if (_.has(transport.transportedSquads, squad.uuid)) {
-          transport.combinedPop = parseFloat(transport.combinedPop) - parseFloat(squad.pop)
+          transport.popWithTransported = parseFloat(transport.popWithTransported) - parseFloat(squad.pop)
           transport.usedSquadSlots -= 1
           transport.usedModelSlots -= squad.totalModelCount
           delete transport.transportedSquads[squad.uuid]
@@ -252,7 +252,7 @@ const squadsSlice = createSlice({
 
         // Uncouple squad from the source transport
         workingSquad.transportUuid = null
-        sourceTransport.combinedPop = parseFloat(sourceTransport.combinedPop) - parseFloat(workingSquad.pop)
+        sourceTransport.popWithTransported = parseFloat(sourceTransport.popWithTransported) - parseFloat(workingSquad.pop)
         sourceTransport.usedSquadSlots -= 1
         sourceTransport.usedModelSlots -= workingSquad.totalModelCount
         delete sourceTransport.transportedSquads[uuid]
@@ -276,7 +276,7 @@ const squadsSlice = createSlice({
         targetTransport.transportedSquads = transportedSquads
         targetTransport.usedSquadSlots = (targetTransport.usedSquadSlots || 0) + 1
         targetTransport.usedModelSlots = (targetTransport.usedModelSlots || 0) + workingSquad.totalModelCount
-        targetTransport.combinedPop = parseFloat(targetTransport.combinedPop) + parseFloat(workingSquad.pop)
+        targetTransport.popWithTransported = parseFloat(targetTransport.popWithTransported) + parseFloat(workingSquad.pop)
       }
 
       state.isChanged = true

--- a/app/javascript/features/companies/manage/units/squadsSlice.js
+++ b/app/javascript/features/companies/manage/units/squadsSlice.js
@@ -401,7 +401,7 @@ const squadsSlice = createSlice({
           workingSquad.totalModelCount += newSquadUpgrade.addModelCount || 0
           if (transportSquad) {
             transportSquad.popWithTransported += newSquadUpgrade.pop || 0
-            transportSquad.transportModelSlots += newSquadUpgrade.addModelCount || 0
+            transportSquad.usedModelSlots += newSquadUpgrade.addModelCount || 0
           }
         }
         state.isChanged = true
@@ -437,7 +437,7 @@ const squadsSlice = createSlice({
         squad.totalModelCount -= squadUpgrade.addModelCount || 0
         if (transport) {
           transport.popWithTransported -= squadUpgrade.pop || 0
-          transport.transportModelSlots += squadUpgrade.addModelCount || 0
+          transport.usedModelSlots -= squadUpgrade.addModelCount || 0
         }
       })
   }
@@ -471,7 +471,7 @@ export const selectSupportSquads = state => state.squads[SUPPORT]
 
 export const selectSquadsInTabIndex = (state, tab, index) => state.squads[tab][index]
 
-export const selectSquadInTabIndexUuid = (state, tab, index, uuid) => state.squads[tab][index][uuid]
+export const selectSquadInTabIndexUuid = (state, tab, index, uuid) => state.squads?.[tab]?.[index]?.[uuid]
 export const selectSquadInTabIndexTransportUuid = (state, tab, index, transportUuid, uuid) => {
   const transport = state.squads[tab][index][transportUuid]
   return transport.transportedSquads[uuid]

--- a/app/javascript/features/companies/manage/units/squadsSlice.js
+++ b/app/javascript/features/companies/manage/units/squadsSlice.js
@@ -264,6 +264,15 @@ const squadsSlice = createSlice({
       if (_.isNil(targetTransportUuid)) {
         // Moving into platoon
         newPlatoon[uuid] = workingSquad
+
+        // If this squad is transporting other squads, update the transported squads
+        if (workingSquad.transportedSquads) {
+          Object.values(workingSquad.transportedSquads).forEach(ts => {
+            ts.tab = newTab
+            ts.index = newIndex
+          })
+        }
+        state.selectedSquadTransportUuid = null
       } else {
         // Moving into transport
         const targetTransport = newPlatoon[targetTransportUuid]
@@ -277,8 +286,12 @@ const squadsSlice = createSlice({
         targetTransport.usedSquadSlots = (targetTransport.usedSquadSlots || 0) + 1
         targetTransport.usedModelSlots = (targetTransport.usedModelSlots || 0) + workingSquad.totalModelCount
         targetTransport.popWithTransported = parseFloat(targetTransport.popWithTransported) + parseFloat(workingSquad.pop)
+        state.selectedSquadTransportUuid = targetTransportUuid
       }
 
+      state.selectedSquadTab = newTab
+      state.selectedSquadIndex = newIndex
+      state.selectedSquadUuid = uuid
       state.isChanged = true
     },
     resetSquadState: () => initialState,

--- a/app/models/squad.rb
+++ b/app/models/squad.rb
@@ -5,6 +5,7 @@
 #  id                                                                :bigint           not null, primary key
 #  category_position(Position within the tab the squad is in)        :integer          not null
 #  name(Squad's custom name)                                         :string
+#  pop(Total pop of the squad including unit and all upgrades)       :decimal(, )
 #  tab_category(Tab this squad is in)                                :string           not null
 #  total_model_count(Total model count of the unit and all upgrades) :integer
 #  uuid(Unique uuid)                                                 :string           not null
@@ -75,7 +76,7 @@ class Squad < ApplicationRecord
     unit.type
   end
 
-  def pop
+  def unit_pop
     available_unit.pop
   end
 
@@ -133,6 +134,7 @@ class Squad < ApplicationRecord
     expose :unit_name, as: :unitName
     expose :unit_display_name, as: :unitDisplayName
     expose :unit_type, as: :unitType
+    expose :unit_pop, as: :unitPop
     expose :pop
     expose :man
     expose :mun

--- a/app/services/company_service.rb
+++ b/app/services/company_service.rb
@@ -224,14 +224,14 @@ class CompanyService
           available_unit = available_units_by_id[s[:available_unit_id]]
           squad = Squad.new(company: company, vet: s[:vet], tab_category: s[:tab], uuid: s[:uuid],
                                   category_position: s[:index], available_unit: available_unit,
-                                  total_model_count: s[:totalModelCount])
+                                  total_model_count: s[:totalModelCount], pop: s[:pop])
           new_squad_upgrades.concat(build_recursive_squad_upgrades(s, squad))
           new_squads << squad
         else
           ## Update existing Squads
           existing_squad = existing_squads_by_id[s[:squad_id]]
           existing_squad.update!(tab_category: s[:tab], category_position: s[:index], name: s[:name],
-                                 total_model_count: s[:totalModelCount])
+                                 total_model_count: s[:totalModelCount], pop: s[:pop])
           new_squad_upgrades.concat(build_recursive_squad_upgrades(s, existing_squad))
         end
       end
@@ -511,6 +511,7 @@ class CompanyService
         squad_pop += available_upgrade.pop
       end
 
+      squad[:pop] = squad_pop
       platoon_pop_by_tab_and_index[squad[:tab]][squad[:index]] += squad_pop
       pop_new += squad_pop
     end

--- a/db/migrate/20211129235745_create_squads.rb
+++ b/db/migrate/20211129235745_create_squads.rb
@@ -8,6 +8,7 @@ class CreateSquads < ActiveRecord::Migration[6.1]
       t.string :uuid, null: false, comment: "Unique uuid"
       t.decimal :vet, comment: "Squad's veterancy"
       t.string :name, comment: "Squad's custom name"
+      t.decimal :pop, comment: "Total pop of the squad including unit and all upgrades"
       t.integer :total_model_count, comment: "Total model count of the unit and all upgrades"
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -431,6 +431,7 @@ ActiveRecord::Schema.define(version: 2023_05_15_015147) do
     t.string "uuid", null: false, comment: "Unique uuid"
     t.decimal "vet", comment: "Squad's veterancy"
     t.string "name", comment: "Squad's custom name"
+    t.decimal "pop", comment: "Total pop of the squad including unit and all upgrades"
     t.integer "total_model_count", comment: "Total model count of the unit and all upgrades"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/seeds/cmw_enabled_upgrades.csv
+++ b/db/seeds/cmw_enabled_upgrades.csv
@@ -77,6 +77,6 @@ bren_gun,CMW.SINGLE_BREN_GUN,Bren Gun,A single Bren Gun,single_weapon,,commandos
 bren_gun,CMW.SINGLE_BREN_GUN,Bren Gun,A single Bren Gun,single_weapon,,commandos,packing_heat,0,20,0,0,0,1,0,1,,,captain
 piat,CMW.SINGLE_PIAT,PIAT,A single PIAT,single_weapon,,commandos,packing_heat,0,30,0,0,0,1,0,1,,,lt
 piat,CMW.SINGLE_PIAT,PIAT,A single PIAT,single_weapon,,commandos,packing_heat,0,30,0,0,0,1,0,1,,,captain
-piat_commando_four,CMW.PIAT_COMMANDO_FOUR,Additional PIAT Commando,Adds another member to the squad,unit_replacement,,commandos,commando_fire_teams,60,10,0,1,0,0,0,1,4,,piat_commandos
+piat_commando_four,CMW.PIAT_COMMANDO_FOUR,Additional PIAT Commando,Adds another member to the squad,unit_replacement,,commandos,commando_fire_teams,60,10,0,1,0,0,0,1,4,1,piat_commandos
 piat_commando_brens,CMW.BREN_GUN,Bren Guns,Replace PIATs with Bren Guns,single_weapon,,commandos,commando_fire_teams,0,0,0,0,0,1,0,1,,,piat_commandos
 piat_commando_boys_at,CMW.BOYSAT,Boys AT Rifles,Replace PIATs with Boys AT Rifles,single_weapon,,commandos,commando_fire_teams,0,0,0,0,0,1,0,1,,,piat_commandos

--- a/spec/services/company_service_spec.rb
+++ b/spec/services/company_service_spec.rb
@@ -1322,6 +1322,14 @@ RSpec.describe CompanyService do
             ruleset.update!(starting_man: 200, starting_mun: 200, starting_fuel: 200)
           end
           it "raises a validation error if the new squads' cost is greater in one or more resource than the ruleset's starting resources" do
+            squad2 = Squad.find_by(uuid: '2')
+            @squad_upgrades_param << {
+              squad_upgrade_id: nil,
+              available_upgrade_id: available_upgrade_2.id,
+              squad_id: squad2.id,
+              squad_uuid: '2'
+            }
+
             expect {
               instance.update_company_squads(company.reload, @squads_param, @offmaps_param, @squad_upgrades_param)
             }.to raise_error(
@@ -1348,6 +1356,7 @@ RSpec.describe CompanyService do
         end
 
         it "raises a validation error if a platoon has too much pop including squad upgrades" do
+          squad2 = Squad.find_by(uuid: '2')
           @squads_param << { squad_id: nil,
                              unit_id: unit3.id,
                              available_unit_id: available_unit_3.id,
@@ -1355,6 +1364,12 @@ RSpec.describe CompanyService do
                              vet: 0,
                              tab: "core",
                              index: 0 }
+          @squad_upgrades_param << {
+            squad_upgrade_id: nil,
+            available_upgrade_id: available_upgrade_2.id,
+            squad_id: squad2.id,
+            squad_uuid: '2'
+          }
           expect {
             instance.update_company_squads(company, @squads_param, @offmaps_param, @squad_upgrades_param)
           }.to raise_error(


### PR DESCRIPTION
* Rename combinedPop to popWithTransported
* Updated company service to calculate squad pop from squad upgrades pop and save on squad record
* Handle moving squads for selectedSquad & squadUpgrade location state updates
* SquadsSlice actions to update pop and model count on adding and removing squad upgrades
* Disable available upgrades if transport has no available model slots