### PR TITLE
Create PlayerRating during omniauth login

### DIFF
--- a/app/models/player_rating.rb
+++ b/app/models/player_rating.rb
@@ -20,5 +20,17 @@
 #  fk_rails_...  (player_id => players.id)
 #
 class PlayerRating < ApplicationRecord
+  DEFAULT_ELO = 1500
+  DEFAULT_MU = 25.0
+  DEFAULT_SIGMA = 25.0 / 3.0
+
   belongs_to :player, inverse_of: :player_rating
+
+  def self.from_historical(player, hpr)
+    PlayerRating.create!(player: player, elo: hpr.elo, mu: hpr.mu, sigma: hpr.sigma, last_played: hpr.last_played)
+  end
+
+  def self.for_new_player(player)
+    PlayerRating.create!(player: player, elo: DEFAULT_ELO, mu: DEFAULT_MU, sigma: DEFAULT_SIGMA, last_played: nil)
+  end
 end

--- a/db/migrate/20211113221946_initial_schema.rb
+++ b/db/migrate/20211113221946_initial_schema.rb
@@ -24,6 +24,8 @@ class InitialSchema < ActiveRecord::Migration[6.1]
       t.timestamps
     end
 
+    add_index :players, [:provider, :uid], unique: true
+
     create_table :doctrines, comment: "Faction doctrines" do |t|
       t.string :name, null: false, comment: "Raw name"
       t.string :display_name, null: false, comment: "Display name"

--- a/db/migrate/20231201053808_create_historical_player_ratings.rb
+++ b/db/migrate/20231201053808_create_historical_player_ratings.rb
@@ -4,8 +4,8 @@ class CreateHistoricalPlayerRatings < ActiveRecord::Migration[6.1]
       t.string :player_name, comment: "historical player name"
       t.references :player, index: true, null: true
       t.integer :elo, comment: "trueskill mu normalized between 1000 and 2000"
-      t.decimal :mu, comment: "trueskill mu"
-      t.decimal :sigma, comment: "trueskill sigma"
+      t.float :mu, comment: "trueskill mu"
+      t.float :sigma, comment: "trueskill sigma"
       t.date :last_played, comment: "last played match"
 
       t.timestamps

--- a/db/migrate/20231201053817_create_player_ratings.rb
+++ b/db/migrate/20231201053817_create_player_ratings.rb
@@ -3,8 +3,8 @@ class CreatePlayerRatings < ActiveRecord::Migration[6.1]
     create_table :player_ratings do |t|
       t.references :player, index: true, foreign_key: true
       t.integer :elo, comment: "trueskill mu normalized between 1000 and 2000"
-      t.decimal :mu, comment: "trueskill mu"
-      t.decimal :sigma, comment: "trueskill sigma"
+      t.float :mu, comment: "trueskill mu"
+      t.float :sigma, comment: "trueskill sigma"
       t.date :last_played, comment: "last played match"
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -262,8 +262,8 @@ ActiveRecord::Schema.define(version: 2023_12_01_053817) do
     t.string "player_name", comment: "historical player name"
     t.bigint "player_id"
     t.integer "elo", comment: "trueskill mu normalized between 1000 and 2000"
-    t.decimal "mu", comment: "trueskill mu"
-    t.decimal "sigma", comment: "trueskill sigma"
+    t.float "mu", comment: "trueskill mu"
+    t.float "sigma", comment: "trueskill sigma"
     t.date "last_played", comment: "last played match"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -291,8 +291,8 @@ ActiveRecord::Schema.define(version: 2023_12_01_053817) do
   create_table "player_ratings", force: :cascade do |t|
     t.bigint "player_id"
     t.integer "elo", comment: "trueskill mu normalized between 1000 and 2000"
-    t.decimal "mu", comment: "trueskill mu"
-    t.decimal "sigma", comment: "trueskill sigma"
+    t.float "mu", comment: "trueskill mu"
+    t.float "sigma", comment: "trueskill sigma"
     t.date "last_played", comment: "last played match"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -313,6 +313,7 @@ ActiveRecord::Schema.define(version: 2023_12_01_053817) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
+    t.index ["provider", "uid"], name: "index_players_on_provider_and_uid", unique: true
   end
 
   create_table "resource_bonuses", force: :cascade do |t|

--- a/spec/factories/historical_player_rating.rb
+++ b/spec/factories/historical_player_rating.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :historical_player_rating do
-    sequence :player_name do |n| "Player #{n}" end
-    association :player
+    sequence :player_name do |n| "Player #{n}".upcase end
     elo { 1500 }
     mu { 25.0 }
     sigma { 8.33333 }

--- a/spec/models/player_rating_spec.rb
+++ b/spec/models/player_rating_spec.rb
@@ -27,4 +27,37 @@ RSpec.describe PlayerRating, type: :model do
   describe 'associations' do
     it { should belong_to(:player) }
   end
+
+  describe "#from_historical" do
+    let!(:player) { create :player }
+    let(:elo) { 1400 }
+    let(:mu) { 24.3484584 }
+    let(:sigma) { 4.294785963 }
+    let(:last_played) { "2023-04-01" }
+    let!(:hpr) { create :historical_player_rating, player_name: player.name, player: nil, elo: elo, mu: mu, sigma: sigma, last_played: last_played }
+
+    subject { described_class.from_historical(player, hpr) }
+
+    it "is created with hpr values" do
+      expect(subject.player).to eq player
+      expect(subject.elo).to eq elo
+      expect(subject.mu).to eq mu
+      expect(subject.sigma).to eq sigma
+      expect(subject.last_played).to eq Date.parse(last_played)
+    end
+  end
+
+  describe "#for_new_player" do
+    let!(:player) { create :player }
+
+    subject { described_class.for_new_player(player) }
+
+    it "is created with default values" do
+      expect(subject.player).to eq player
+      expect(subject.elo).to eq PlayerRating::DEFAULT_ELO
+      expect(subject.mu).to eq PlayerRating::DEFAULT_MU
+      expect(subject.sigma).to eq PlayerRating::DEFAULT_SIGMA
+      expect(subject.last_played).to be nil
+    end
+  end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -17,10 +17,14 @@
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #
+# Indexes
+#
+#  index_players_on_provider_and_uid  (provider,uid) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe Player, type: :model do
-  let!(:player) { create :player}
+  let!(:player) { create :player }
 
   describe 'associations' do
     it { should have_many(:companies) }
@@ -28,5 +32,99 @@ RSpec.describe Player, type: :model do
     it { should have_many(:doctrines) }
     it { should have_one(:player_rating) }
     it { should have_many(:historical_player_ratings) }
+  end
+
+  describe "#from_omniauth" do
+    let!(:player) { create :player }
+    let(:nickname) { "nickname" }
+    let(:image) { "www.image.com" }
+    let(:info_double) { double("info", nickname: nickname, image: image) }
+    let(:provider) { "provider" }
+    let(:uid) { "1234" }
+    let(:auth_double) { double("auth", info: info_double, provider: provider, uid: uid) }
+
+    subject { described_class.from_omniauth(auth_double) }
+
+    context "when there is no player for the provider and uid values" do
+      it "creates a Player" do
+        expect { subject }.to change { Player.count }.by 1
+
+        p = Player.last
+        expect(p.name).to eq nickname
+        expect(p.avatar).to eq image
+        expect(p.provider).to eq provider
+        expect(p.uid).to eq uid
+      end
+
+      context "when there is no historical player rating" do
+        it "creates a PlayerRating with default values" do
+          expect { subject }.to change { PlayerRating.count }.by 1
+          pr = PlayerRating.last
+
+          expect(pr.player).to eq Player.last
+          expect(pr.player.provider).to eq provider
+          expect(pr.player.uid).to eq uid
+          expect(pr.elo).to eq PlayerRating::DEFAULT_ELO
+          expect(pr.mu).to eq PlayerRating::DEFAULT_MU
+          expect(pr.sigma).to eq PlayerRating::DEFAULT_SIGMA
+          expect(pr.last_played).to be nil
+        end
+      end
+
+      context "when there is no matching historical player rating with the same name" do
+        let!(:hpr) { create :historical_player_rating, player_name: "some other name",
+                            player: nil, elo: 1233, mu: 21.2, sigma: 3.2312, last_played: Date.parse("2023-01-01") }
+
+        it "creates a PlayerRating with default values" do
+          expect { subject }.to change { PlayerRating.count }.by 1
+          pr = PlayerRating.last
+
+          expect(pr.player).to eq Player.last
+          expect(pr.player.provider).to eq provider
+          expect(pr.player.uid).to eq uid
+          expect(pr.elo).to eq PlayerRating::DEFAULT_ELO
+          expect(pr.mu).to eq PlayerRating::DEFAULT_MU
+          expect(pr.sigma).to eq PlayerRating::DEFAULT_SIGMA
+          expect(pr.last_played).to be nil
+        end
+      end
+
+      context "when there is a matching historical player rating" do
+        let(:elo) { 1400 }
+        let(:mu) { 24.3484584 }
+        let(:sigma) { 4.294785963 }
+        let(:last_played) { "2023-04-01" }
+        let!(:hpr) { create :historical_player_rating, player_name: nickname.upcase, player: nil, elo: elo, mu: mu, sigma: sigma, last_played: last_played }
+
+        it "creates a PlayerRating with historical player rating values" do
+          expect { subject }.to change { PlayerRating.count }.by 1
+          pr = PlayerRating.last
+
+          expect(pr.player).to eq Player.last
+          expect(pr.player.provider).to eq provider
+          expect(pr.player.uid).to eq uid
+          expect(pr.elo).to eq elo
+          expect(pr.mu).to eq mu
+          expect(pr.sigma).to eq sigma
+          expect(pr.last_played).to eq Date.parse(last_played)
+        end
+      end
+    end
+
+    context "when there is an existing player for the provider and uid values" do
+      let!(:player) { create :player, provider: provider, uid: uid }
+
+      it "updates the existing player" do
+        expect { subject }.not_to change { Player.count }
+        expect(player.reload.name).to eq nickname
+        expect(player.avatar).to eq image
+        expect(player.provider).to eq provider
+        expect(player.uid).to eq uid
+      end
+
+      it "does not create a PlayerRating" do
+        expect { subject }.not_to change { PlayerRating.count }
+      end
+    end
   end
 end


### PR DESCRIPTION
Historical Player Rating is a table of player elos from the legacy site.

On Player omniauth login, if a new player, we want to attempt to match their user name with historical player rating of the same name.
If a match is found, create a `PlayerRating` with those stats. If not, create a `PlayerRating` with default stats