### PR TITLE
Add HistoricalBattlePlayer

### DIFF
--- a/app/models/historical_battle_player.rb
+++ b/app/models/historical_battle_player.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: historical_battle_players
+#
+#  id                                                                                    :bigint           not null, primary key
+#  elo(Trueskill mu normalized, after battle)                                            :integer
+#  is_winner(Whether the player won)                                                     :string           not null
+#  losses(losses to date)                                                                :integer          default(0)
+#  mu(Trueskill mu, after battle)                                                        :float
+#  player_name(Denormalized player name in case player record is deleted)                :string           not null
+#  sigma(Trueskill sigma, after battle)                                                  :float
+#  wins(wins to date)                                                                    :integer          default(0)
+#  created_at                                                                            :datetime         not null
+#  updated_at                                                                            :datetime         not null
+#  battle_id(Battle id, could be duplicates in the long run through multiple war resets) :string           not null
+#  doctrine_id                                                                           :bigint           not null
+#  player_id                                                                             :bigint
+#
+# Indexes
+#
+#  index_historical_battle_players_on_doctrine_id  (doctrine_id)
+#  index_historical_battle_players_on_player_id    (player_id)
+#  index_historical_battle_players_on_player_name  (player_name)
+#
+class HistoricalBattlePlayer < ApplicationRecord
+  belongs_to :player, inverse_of: :historical_battle_players, optional: true
+  belongs_to :doctrine
+end

--- a/app/models/historical_battle_player.rb
+++ b/app/models/historical_battle_player.rb
@@ -14,15 +14,18 @@
 #  updated_at                                                                            :datetime         not null
 #  battle_id(Battle id, could be duplicates in the long run through multiple war resets) :string           not null
 #  doctrine_id                                                                           :bigint           not null
+#  faction_id                                                                            :bigint           not null
 #  player_id                                                                             :bigint
 #
 # Indexes
 #
 #  index_historical_battle_players_on_doctrine_id  (doctrine_id)
+#  index_historical_battle_players_on_faction_id   (faction_id)
 #  index_historical_battle_players_on_player_id    (player_id)
 #  index_historical_battle_players_on_player_name  (player_name)
 #
 class HistoricalBattlePlayer < ApplicationRecord
   belongs_to :player, inverse_of: :historical_battle_players, optional: true
+  belongs_to :faction
   belongs_to :doctrine
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -58,6 +58,7 @@ class Player < ApplicationRecord
   has_many :factions, through: :companies
   has_one :player_rating, inverse_of: :player
   has_many :historical_player_ratings, inverse_of: :player
+  has_many :historical_battle_players, inverse_of: :player
 
   def entity
     Entity.new(self)

--- a/db/migrate/20231210051226_create_historical_battle_player.rb
+++ b/db/migrate/20231210051226_create_historical_battle_player.rb
@@ -1,0 +1,20 @@
+class CreateHistoricalBattlePlayer < ActiveRecord::Migration[6.1]
+  def change
+    create_table :historical_battle_players, comment: "Historical record of battle results by player" do |t|
+      t.references :player, index: true, null: true
+      t.string :player_name, null: false, comment: "Denormalized player name in case player record is deleted"
+      t.string :battle_id, null: false, comment: "Battle id, could be duplicates in the long run through multiple war resets"
+      t.references :doctrine, index: true, null: false
+      t.string :is_winner, null: false, comment: "Whether the player won"
+      t.integer :elo, comment: "Trueskill mu normalized, after battle"
+      t.float :mu, comment: "Trueskill mu, after battle"
+      t.float :sigma, comment: "Trueskill sigma, after battle"
+      t.integer :wins, default: 0, comment: "wins to date"
+      t.integer :losses, default: 0, comment: "losses to date"
+
+      t.timestamps
+    end
+
+    add_index :historical_battle_players, :player_name
+  end
+end

--- a/db/migrate/20231210051226_create_historical_battle_player.rb
+++ b/db/migrate/20231210051226_create_historical_battle_player.rb
@@ -4,6 +4,7 @@ class CreateHistoricalBattlePlayer < ActiveRecord::Migration[6.1]
       t.references :player, index: true, null: true
       t.string :player_name, null: false, comment: "Denormalized player name in case player record is deleted"
       t.string :battle_id, null: false, comment: "Battle id, could be duplicates in the long run through multiple war resets"
+      t.references :faction, index: true, null: false
       t.references :doctrine, index: true, null: false
       t.string :is_winner, null: false, comment: "Whether the player won"
       t.integer :elo, comment: "Trueskill mu normalized, after battle"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_07_042011) do
+ActiveRecord::Schema.define(version: 2023_12_10_051226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -258,6 +258,24 @@ ActiveRecord::Schema.define(version: 2023_12_07_042011) do
     t.string "name", comment: "Game name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "historical_battle_players", comment: "Historical record of battle results by player", force: :cascade do |t|
+    t.bigint "player_id"
+    t.string "player_name", null: false, comment: "Denormalized player name in case player record is deleted"
+    t.string "battle_id", null: false, comment: "Battle id, could be duplicates in the long run through multiple war resets"
+    t.bigint "doctrine_id", null: false
+    t.string "is_winner", null: false, comment: "Whether the player won"
+    t.integer "elo", comment: "Trueskill mu normalized, after battle"
+    t.float "mu", comment: "Trueskill mu, after battle"
+    t.float "sigma", comment: "Trueskill sigma, after battle"
+    t.integer "wins", default: 0, comment: "wins to date"
+    t.integer "losses", default: 0, comment: "losses to date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["doctrine_id"], name: "index_historical_battle_players_on_doctrine_id"
+    t.index ["player_id"], name: "index_historical_battle_players_on_player_id"
+    t.index ["player_name"], name: "index_historical_battle_players_on_player_name"
   end
 
   create_table "historical_player_ratings", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -264,6 +264,7 @@ ActiveRecord::Schema.define(version: 2023_12_10_051226) do
     t.bigint "player_id"
     t.string "player_name", null: false, comment: "Denormalized player name in case player record is deleted"
     t.string "battle_id", null: false, comment: "Battle id, could be duplicates in the long run through multiple war resets"
+    t.bigint "faction_id", null: false
     t.bigint "doctrine_id", null: false
     t.string "is_winner", null: false, comment: "Whether the player won"
     t.integer "elo", comment: "Trueskill mu normalized, after battle"
@@ -274,6 +275,7 @@ ActiveRecord::Schema.define(version: 2023_12_10_051226) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["doctrine_id"], name: "index_historical_battle_players_on_doctrine_id"
+    t.index ["faction_id"], name: "index_historical_battle_players_on_faction_id"
     t.index ["player_id"], name: "index_historical_battle_players_on_player_id"
     t.index ["player_name"], name: "index_historical_battle_players_on_player_name"
   end

--- a/spec/factories/historical_battle_player.rb
+++ b/spec/factories/historical_battle_player.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :historical_battle_player do
+    association :player
+    player_name { "" }
+    sequence :battle_id do |n| "Battle #{n}" end
+    association :doctrine
+    is_winner { true }
+    elo { 1500 }
+    mu { 25.0 }
+    sigma { 8.33333 }
+    wins { 1 }
+    losses { 0 }
+
+    after(:create) do |hbp|
+      hbp.update!(player_name: hbp.player.name)
+    end
+  end
+end

--- a/spec/factories/historical_battle_player.rb
+++ b/spec/factories/historical_battle_player.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :player
     player_name { "" }
     sequence :battle_id do |n| "Battle #{n}" end
+    association :faction
     association :doctrine
     is_winner { true }
     elo { 1500 }

--- a/spec/models/historical_battle_player_spec.rb
+++ b/spec/models/historical_battle_player_spec.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: historical_battle_players
+#
+#  id                                                                                    :bigint           not null, primary key
+#  elo(Trueskill mu normalized, after battle)                                            :integer
+#  is_winner(Whether the player won)                                                     :string           not null
+#  losses(losses to date)                                                                :integer          default(0)
+#  mu(Trueskill mu, after battle)                                                        :float
+#  player_name(Denormalized player name in case player record is deleted)                :string           not null
+#  sigma(Trueskill sigma, after battle)                                                  :float
+#  wins(wins to date)                                                                    :integer          default(0)
+#  created_at                                                                            :datetime         not null
+#  updated_at                                                                            :datetime         not null
+#  battle_id(Battle id, could be duplicates in the long run through multiple war resets) :string           not null
+#  doctrine_id                                                                           :bigint           not null
+#  player_id                                                                             :bigint
+#
+# Indexes
+#
+#  index_historical_battle_players_on_doctrine_id  (doctrine_id)
+#  index_historical_battle_players_on_player_id    (player_id)
+#  index_historical_battle_players_on_player_name  (player_name)
+#
+require "rails_helper"
+
+RSpec.describe HistoricalBattlePlayer, type: :model do
+  let!(:historical_battle_player) { create :historical_battle_player }
+
+  describe 'associations' do
+    it { should belong_to(:player).optional }
+    it { should belong_to(:doctrine) }
+  end
+end

--- a/spec/models/historical_battle_player_spec.rb
+++ b/spec/models/historical_battle_player_spec.rb
@@ -14,11 +14,13 @@
 #  updated_at                                                                            :datetime         not null
 #  battle_id(Battle id, could be duplicates in the long run through multiple war resets) :string           not null
 #  doctrine_id                                                                           :bigint           not null
+#  faction_id                                                                            :bigint           not null
 #  player_id                                                                             :bigint
 #
 # Indexes
 #
 #  index_historical_battle_players_on_doctrine_id  (doctrine_id)
+#  index_historical_battle_players_on_faction_id   (faction_id)
 #  index_historical_battle_players_on_player_id    (player_id)
 #  index_historical_battle_players_on_player_name  (player_name)
 #
@@ -29,6 +31,7 @@ RSpec.describe HistoricalBattlePlayer, type: :model do
 
   describe 'associations' do
     it { should belong_to(:player).optional }
+    it { should belong_to(:faction) }
     it { should belong_to(:doctrine) }
   end
 end


### PR DESCRIPTION
Add a new HistoricalBattlePlayer model to hold post battle player records. We should create a record for every player who participates in a battle, with their post match information about:
* did they win
* who they are
* what doctrine
* what faction
* elo/mu/sigma
* win/loss