### PR TITLE
Services to save company stats after battle report

### DIFF
--- a/app/models/battle.rb
+++ b/app/models/battle.rb
@@ -35,6 +35,8 @@ class Battle < ApplicationRecord
     axis: "axis"
   }
 
+  BATTLE_SIZES = [1,2,3,4].freeze
+
   validates_presence_of :ruleset
   validates_presence_of :size
   validates_numericality_of :size

--- a/app/models/battle_player.rb
+++ b/app/models/battle_player.rb
@@ -48,6 +48,10 @@ class BattlePlayer < ApplicationRecord
     player.player_rating.elo
   end
 
+  def win?
+    side == battle.winner
+  end
+
   def entity
     Entity.new(self)
   end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,16 @@
+class ApplicationService
+
+  private
+
+  def error_logger(msg)
+    Rails.logger.error("[#{self.class.name}] #{msg}")
+  end
+
+  def warn_logger(msg)
+    Rails.logger.warn("[#{self.class.name}] #{msg}")
+  end
+
+  def info_logger(msg)
+    Rails.logger.info("[#{self.class.name}] #{msg}")
+  end
+end

--- a/app/services/battle_report_stats/report_parse_service.rb
+++ b/app/services/battle_report_stats/report_parse_service.rb
@@ -1,0 +1,44 @@
+module BattleReportStats
+  class ReportParseService < ApplicationService
+    def initialize(battle_id, battle_stats_string)
+      @battle = Battle.includes(battle_players: :company).find_by!(id: battle_id)
+      @battle_stats_string = battle_stats_string
+    end
+
+    def process_battle_stats
+      stats_by_company_id = parse_stats
+
+      @battle.battle_players.each do |bp|
+        company_id = bp.company_id
+        stats = stats_by_company_id[company_id]
+        save_company_stats(company_id, stats, @battle.final?, bp.win?)
+      end
+    end
+
+    private
+
+    "Razor,CompanyId:13,Inf Lost:3 ,Vehicles Lost:0 ,Inf Killed:1 ,Vehicles Killed:0;UnLimiTeD,CompanyId:11,Inf Lost:1 ,Vehicles Lost:0 ,Inf Killed:3 ,Vehicles Killed:0;"
+    def parse_stats
+      stats_by_player = @battle_stats_string.split(";")
+      stats_by_player.reduce({}) do |acc, player_stats_string|
+        elements = player_stats_string.split(",")
+        company_id = get_value_from_stat_string(elements[1])
+        acc[company_id] = {
+          inf_lost: get_value_from_stat_string(elements[2]),
+          vehicles_lost: get_value_from_stat_string(elements[3]),
+          inf_killed: get_value_from_stat_string(elements[4]),
+          vehicles_killed: get_value_from_stat_string(elements[5])
+        }
+        acc
+      end
+    end
+
+    def save_company_stats(company_id, new_stats, is_final, is_winner)
+      UpdateService.new(company_id).update_company_stats(@battle.size, new_stats, is_final, is_winner)
+    end
+
+    def get_value_from_stat_string(stat_string)
+      stat_string.split(":").second.to_i
+    end
+  end
+end

--- a/app/services/battle_report_stats/update_service.rb
+++ b/app/services/battle_report_stats/update_service.rb
@@ -1,0 +1,44 @@
+module BattleReportStats
+  class UpdateService < ApplicationService
+    class UpdateServiceValidationError < StandardError; end
+
+    def initialize(company_id)
+      @company_stats = CompanyStats.find_by(company_id: company_id)
+    end
+
+    # Add these new stats for the company to the existing company stats record
+    # TODO Could we have company stats update for non-final battle?
+    def update_company_stats(battle_size, new_stats, is_final, is_winner)
+      vs_string(battle_size)
+
+      # Update kill loss stats
+      @company_stats["infantry_kills_#{@vs_string}"] += new_stats[:inf_killed]
+      @company_stats["infantry_losses_#{@vs_string}"] += new_stats[:inf_lost]
+      @company_stats["vehicle_kills_#{@vs_string}"] += new_stats[:vehicles_killed]
+      @company_stats["vehicle_losses_#{@vs_string}"] += new_stats[:vehicles_lost]
+
+      # If final, update wins, losses, streak stats
+      if is_final
+        if is_winner
+          @company_stats["wins_#{@vs_string}"] += 1
+          @company_stats["streak_#{@vs_string}"] += 1
+        else
+          @company_stats["losses_#{@vs_string}"] += 1
+          @company_stats["streak_#{@vs_string}"] = 0
+        end
+      end
+
+      @company_stats.save!
+    end
+
+    private
+
+    def validate_battle_size(battle_size)
+      raise UpdateServiceValidationError.new("Invalid battle size: #{battle_size}") unless Battle::BATTLE_SIZES.include?(battle_size)
+    end
+
+    def vs_string(battle_size)
+      @vs_string ||= "#{battle_size}v#{battle_size}"
+    end
+  end
+end

--- a/spec/services/battle_report_stats/report_parse_service_spec.rb
+++ b/spec/services/battle_report_stats/report_parse_service_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe BattleReportStats::ReportParseService do
+  let!(:player1) { create :player }
+  let!(:player2) { create :player }
+  let(:ruleset) { create :ruleset }
+  let(:state) { "final" }
+  let(:size) { 1 }
+  let!(:battle) { create :battle, ruleset: ruleset, state: state, size: size, winner: "allied" }
+
+  let!(:company1) { create :company, player: player1, ruleset: ruleset }
+  let!(:company2) { create :company, player: player2, ruleset: ruleset }
+  let!(:company_stats1) { create :company_stats, company: company1 }
+  let!(:company_stats2) { create :company_stats, company: company2 }
+
+  let(:update_service_double1) { instance_double("BattleReportStats::UpdateService") }
+  let(:update_service_double2) { instance_double("BattleReportStats::UpdateService") }
+
+  before do
+    create :battle_player, battle: battle, player: player1, company: company1, side: "allied"
+    create :battle_player, battle: battle, player: player2, company: company2, side: "axis"
+    allow(BattleReportStats::UpdateService).to receive(:new).with(company1.id).and_return(update_service_double1)
+    allow(BattleReportStats::UpdateService).to receive(:new).with(company2.id).and_return(update_service_double2)
+  end
+
+  describe "#process_battle_stats" do
+    let(:inf_lost1) { 24 }
+    let(:veh_lost1) { 3 }
+    let(:inf_killed1) { 56 }
+    let(:veh_killed1) { 1 }
+    let(:inf_lost2) { 56 }
+    let(:veh_lost2) { 1 }
+    let(:inf_killed2) { 24 }
+    let(:veh_killed2) { 3 }
+
+    let(:stats_string) { "#{player1.name},CompanyId:#{company1.id},Inf Lost:#{inf_lost1} ,Vehicles Lost:#{veh_lost1} ,Inf Killed:#{inf_killed1} ,Vehicles Killed:#{veh_killed1};
+#{player2.name},CompanyId:#{company2.id},Inf Lost:#{inf_lost2} ,Vehicles Lost:#{veh_lost2} ,Inf Killed:#{inf_killed2} ,Vehicles Killed:#{veh_killed2}" }
+
+    context "when battle is final" do
+      subject { described_class.new(battle.id, stats_string).process_battle_stats }
+
+      it "calls the update service for the winner" do
+        expect(update_service_double1).to receive(:update_company_stats).with(
+          size,
+          {
+            inf_lost: inf_lost1,
+            vehicles_lost: veh_lost1,
+            inf_killed: inf_killed1,
+            vehicles_killed: veh_killed1
+          },
+          true,
+          true)
+        allow(update_service_double2).to receive(:update_company_stats)
+
+        subject
+      end
+
+      it "calls the update service for the winner" do
+        allow(update_service_double1).to receive(:update_company_stats)
+        expect(update_service_double2).to receive(:update_company_stats).with(
+          size,
+          {
+            inf_lost: inf_lost2,
+            vehicles_lost: veh_lost2,
+            inf_killed: inf_killed2,
+            vehicles_killed: veh_killed2
+          },
+          true,
+          false)
+
+        subject
+      end
+    end
+    context "when battle is not final" do
+      let(:state) { "ingame" }
+
+      subject { described_class.new(battle.id, stats_string).process_battle_stats }
+
+      it "calls the update service for the winner" do
+        expect(update_service_double1).to receive(:update_company_stats).with(
+          size,
+          {
+            inf_lost: inf_lost1,
+            vehicles_lost: veh_lost1,
+            inf_killed: inf_killed1,
+            vehicles_killed: veh_killed1
+          },
+          false,
+          true)
+        allow(update_service_double2).to receive(:update_company_stats)
+
+        subject
+      end
+
+      it "calls the update service for the winner" do
+        allow(update_service_double1).to receive(:update_company_stats)
+        expect(update_service_double2).to receive(:update_company_stats).with(
+          size,
+          {
+            inf_lost: inf_lost2,
+            vehicles_lost: veh_lost2,
+            inf_killed: inf_killed2,
+            vehicles_killed: veh_killed2
+          },
+          false,
+          false)
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/services/battle_report_stats/update_service_spec.rb
+++ b/spec/services/battle_report_stats/update_service_spec.rb
@@ -1,0 +1,171 @@
+require "rails_helper"
+
+RSpec.describe BattleReportStats::UpdateService do
+  let!(:player1) { create :player }
+  let!(:player2) { create :player }
+  let(:ruleset) { create :ruleset }
+  let(:state) { "final" }
+  let(:size) { 1 }
+  let!(:battle) { create :battle, ruleset: ruleset, state: state, size: size, winner: "allied" }
+
+  let!(:company1) { create :company, player: player1, ruleset: ruleset }
+  let!(:company2) { create :company, player: player2, ruleset: ruleset }
+  let!(:company_stats1) { create :company_stats, company: company1 }
+  let!(:company_stats2) { create :company_stats, company: company2 }
+
+  let(:inf_lost1) { 24 }
+  let(:veh_lost1) { 3 }
+  let(:inf_killed1) { 56 }
+  let(:veh_killed1) { 1 }
+  let(:inf_lost2) { 56 }
+  let(:veh_lost2) { 1 }
+  let(:inf_killed2) { 24 }
+  let(:veh_killed2) { 3 }
+
+  let(:new_stats) { {
+    inf_killed: inf_killed,
+    vehicles_killed: vehicles_killed,
+    inf_lost: inf_lost,
+    vehicles_lost: vehicles_lost
+  } }
+
+  describe "#update_company_stats" do
+    subject { described_class.new(company_id).update_company_stats(size, new_stats, is_final, is_winner) }
+
+    context "when battle is final" do
+      let(:is_final) { true }
+
+      context "when the company is the winner" do
+        let(:company_id) { company1.id }
+        let(:is_winner) { true }
+        let(:inf_killed) { inf_killed1 }
+        let(:vehicles_killed) { veh_killed1 }
+        let(:inf_lost) { inf_lost1 }
+        let(:vehicles_lost) { veh_lost1 }
+
+        it "updates infantry and vehicle kill loss" do
+          subject
+
+          expect(company_stats1.reload.infantry_kills_1v1).to eq inf_killed1
+          expect(company_stats1.vehicle_kills_1v1).to eq veh_killed1
+          expect(company_stats1.infantry_losses_1v1).to eq inf_lost1
+          expect(company_stats1.vehicle_losses_1v1).to eq veh_lost1
+        end
+
+        it "updates wins and streak" do
+          subject
+
+          expect(company_stats1.reload.wins_1v1).to eq 1
+          expect(company_stats1.reload.streak_1v1).to eq 1
+          expect(company_stats1.reload.losses_1v1).to eq 0
+        end
+
+        context "when there are existing stats" do
+
+          let!(:company_stats1) { create :company_stats, company: company1,
+                                         infantry_kills_1v1: 542, vehicle_kills_1v1: 21,
+                                         infantry_losses_1v1: 239, vehicle_losses_1v1: 12,
+                                         wins_1v1: 4, streak_1v1: 3, losses_1v1: 2 }
+
+          it "updates infantry and vehicle kill loss" do
+            subject
+
+            expect(company_stats1.reload.infantry_kills_1v1).to eq inf_killed1 + 542
+            expect(company_stats1.vehicle_kills_1v1).to eq veh_killed1 + 21
+            expect(company_stats1.infantry_losses_1v1).to eq inf_lost1 + 239
+            expect(company_stats1.vehicle_losses_1v1).to eq veh_lost1 + 12
+          end
+
+          it "updates wins and streak" do
+            subject
+
+            expect(company_stats1.reload.wins_1v1).to eq 5
+            expect(company_stats1.reload.streak_1v1).to eq 4
+            expect(company_stats1.reload.losses_1v1).to eq 2
+          end
+        end
+      end
+
+      context "when the company is the loser" do
+        let(:company_id) { company2.id }
+        let(:is_winner) { false }
+        let(:inf_killed) { inf_killed2 }
+        let(:vehicles_killed) { veh_killed2 }
+        let(:inf_lost) { inf_lost2 }
+        let(:vehicles_lost) { veh_lost2 }
+
+        it "updates infantry and vehicle kill loss" do
+          subject
+
+          expect(company_stats2.reload.infantry_kills_1v1).to eq inf_killed2
+          expect(company_stats2.vehicle_kills_1v1).to eq veh_killed2
+          expect(company_stats2.infantry_losses_1v1).to eq inf_lost2
+          expect(company_stats2.vehicle_losses_1v1).to eq veh_lost2
+        end
+
+        it "updates wins and streak" do
+          subject
+
+          expect(company_stats2.reload.wins_1v1).to eq 0
+          expect(company_stats2.reload.streak_1v1).to eq 0
+          expect(company_stats2.reload.losses_1v1).to eq 1
+        end
+      end
+    end
+    context "when battle is not final" do
+      let(:is_final) { false }
+
+      context "when the company is the winner" do
+        let(:company_id) { company1.id }
+        let(:is_winner) { true }
+        let(:inf_killed) { inf_killed1 }
+        let(:vehicles_killed) { veh_killed1 }
+        let(:inf_lost) { inf_lost1 }
+        let(:vehicles_lost) { veh_lost1 }
+
+        it "updates infantry and vehicle kill loss" do
+          subject
+
+          expect(company_stats1.reload.infantry_kills_1v1).to eq inf_killed1
+          expect(company_stats1.vehicle_kills_1v1).to eq veh_killed1
+          expect(company_stats1.infantry_losses_1v1).to eq inf_lost1
+          expect(company_stats1.vehicle_losses_1v1).to eq veh_lost1
+        end
+
+        it "does not update wins and streak" do
+          subject
+
+          expect(company_stats1.reload.wins_1v1).to eq 0
+          expect(company_stats1.reload.streak_1v1).to eq 0
+          expect(company_stats1.reload.losses_1v1).to eq 0
+        end
+      end
+
+      context "when the company is the loser" do
+        let(:company_id) { company2.id }
+        let(:is_winner) { false }
+        let(:inf_killed) { inf_killed2 }
+        let(:vehicles_killed) { veh_killed2 }
+        let(:inf_lost) { inf_lost2 }
+        let(:vehicles_lost) { veh_lost2 }
+
+        it "updates infantry and vehicle kill loss" do
+          subject
+
+          expect(company_stats2.reload.infantry_kills_1v1).to eq inf_killed2
+          expect(company_stats2.vehicle_kills_1v1).to eq veh_killed2
+          expect(company_stats2.infantry_losses_1v1).to eq inf_lost2
+          expect(company_stats2.vehicle_losses_1v1).to eq veh_lost2
+        end
+
+        it "does not update wins and streak" do
+          subject
+
+          expect(company_stats2.reload.wins_1v1).to eq 0
+          expect(company_stats2.reload.streak_1v1).to eq 0
+          expect(company_stats2.reload.losses_1v1).to eq 0
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Services to parse the battle report stats string and update each participating companies' `CompanyStats` record