### PR TITLE
Add Company subclasses ActiveCompany, SnapshotCompany

### DIFF
--- a/app/api/omg/companies.rb
+++ b/app/api/omg/companies.rb
@@ -116,7 +116,7 @@ module OMG
         post 'squads' do
           begin
             declared_params = declared(params)
-            company = Company.includes(:ruleset, :available_units,
+            company = ActiveCompany.includes(:ruleset, :available_units,
                                        { squads: { squad_upgrades: :upgrade },
                                          available_upgrades: :upgrade,
                                          available_offmaps: :offmap,

--- a/app/api/omg/company_unlocks.rb
+++ b/app/api/omg/company_unlocks.rb
@@ -19,7 +19,7 @@ module OMG
       end
       post 'purchase' do
         declared_params = declared(params)
-        company = Company.includes(:company_unlocks, :squads, :ruleset, :available_units, company_resource_bonuses: :resource_bonus).find_by(id: declared_params[:id], player: current_player)
+        company = ActiveCompany.includes(:company_unlocks, :squads, :ruleset, :available_units, company_resource_bonuses: :resource_bonus).find_by(id: declared_params[:id], player: current_player)
         doctrine_unlock = DoctrineUnlock.includes(:unlock).find(declared_params[:doctrineUnlockId])
         service = CompanyUnlockService.new(company)
         service.purchase_doctrine_unlock(doctrine_unlock)
@@ -33,7 +33,7 @@ module OMG
       end
       post 'refund' do
         declared_params = declared(params)
-        company = Company.includes(:company_unlocks, :squads, :ruleset, :available_units, company_resource_bonuses: :resource_bonus).find_by(id: declared_params[:id], player: current_player)
+        company = ActiveCompany.includes(:company_unlocks, :squads, :ruleset, :available_units, company_resource_bonuses: :resource_bonus).find_by(id: declared_params[:id], player: current_player)
         company_unlock = CompanyUnlock.find(declared_params[:companyUnlockId])
         service = CompanyUnlockService.new(company)
         service.refund_company_unlock(declared_params[:companyUnlockId])

--- a/app/models/active_company.rb
+++ b/app/models/active_company.rb
@@ -1,0 +1,37 @@
+# == Schema Information
+#
+# Table name: companies
+#
+#  id                                       :bigint           not null, primary key
+#  fuel(Fuel available to this company)     :integer          default(0)
+#  man(Manpower available to this company)  :integer          default(0)
+#  mun(Munitions available to this company) :integer          default(0)
+#  name(Company name)                       :string
+#  pop(Population cost of this company)     :integer          default(0)
+#  type(Company type)                       :string
+#  vps_current(VPs available to spend)      :integer          default(0), not null
+#  vps_earned(VPs earned by this company)   :integer          default(0), not null
+#  created_at                               :datetime         not null
+#  updated_at                               :datetime         not null
+#  doctrine_id                              :bigint           not null
+#  faction_id                               :bigint           not null
+#  player_id                                :bigint           not null
+#  ruleset_id                               :bigint           not null
+#
+# Indexes
+#
+#  index_companies_on_doctrine_id  (doctrine_id)
+#  index_companies_on_faction_id   (faction_id)
+#  index_companies_on_player_id    (player_id)
+#  index_companies_on_ruleset_id   (ruleset_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (doctrine_id => doctrines.id)
+#  fk_rails_...  (faction_id => factions.id)
+#  fk_rails_...  (player_id => players.id)
+#  fk_rails_...  (ruleset_id => rulesets.id)
+#
+class ActiveCompany < Company
+
+end

--- a/app/models/battle_player.rb
+++ b/app/models/battle_player.rb
@@ -44,7 +44,6 @@ class BattlePlayer < ApplicationRecord
     company.doctrine.name
   end
 
-  # TODO Are we sure we want to surface this?
   def player_elo
     player.player_rating.elo
   end

--- a/app/models/snapshot_company.rb
+++ b/app/models/snapshot_company.rb
@@ -1,0 +1,37 @@
+# == Schema Information
+#
+# Table name: companies
+#
+#  id                                       :bigint           not null, primary key
+#  fuel(Fuel available to this company)     :integer          default(0)
+#  man(Manpower available to this company)  :integer          default(0)
+#  mun(Munitions available to this company) :integer          default(0)
+#  name(Company name)                       :string
+#  pop(Population cost of this company)     :integer          default(0)
+#  type(Company type)                       :string
+#  vps_current(VPs available to spend)      :integer          default(0), not null
+#  vps_earned(VPs earned by this company)   :integer          default(0), not null
+#  created_at                               :datetime         not null
+#  updated_at                               :datetime         not null
+#  doctrine_id                              :bigint           not null
+#  faction_id                               :bigint           not null
+#  player_id                                :bigint           not null
+#  ruleset_id                               :bigint           not null
+#
+# Indexes
+#
+#  index_companies_on_doctrine_id  (doctrine_id)
+#  index_companies_on_faction_id   (faction_id)
+#  index_companies_on_player_id    (player_id)
+#  index_companies_on_ruleset_id   (ruleset_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (doctrine_id => doctrines.id)
+#  fk_rails_...  (faction_id => factions.id)
+#  fk_rails_...  (player_id => players.id)
+#  fk_rails_...  (ruleset_id => rulesets.id)
+#
+class SnapshotCompany < Company
+
+end

--- a/app/services/battle_report_service.rb
+++ b/app/services/battle_report_service.rb
@@ -217,7 +217,7 @@ class BattleReportService < ApplicationService
     player_ids = @battle.players.pluck(:id)
     ruleset_id = @battle.ruleset_id
     info_logger("Start adding VPs to Companies for players #{player_ids} in ruleset #{ruleset_id}")
-    companies = Company.where(player_id: player_ids, ruleset_id: ruleset_id)
+    companies = ActiveCompany.where(player_id: player_ids, ruleset_id: ruleset_id)
     companies_to_update = []
     companies.each do |c|
       if c.vps_earned >= @ruleset.max_vps
@@ -229,7 +229,7 @@ class BattleReportService < ApplicationService
         companies_to_update << c
       end
     end
-    Company.import!(companies_to_update, on_duplicate_key_update: { conflict_target: [:id], columns: [:vps_earned, :vps_current] })
+    ActiveCompany.import!(companies_to_update, on_duplicate_key_update: { conflict_target: [:id], columns: [:vps_earned, :vps_current] })
   end
 
   # Player VPs are used to repopulate

--- a/app/services/battle_service.rb
+++ b/app/services/battle_service.rb
@@ -316,7 +316,7 @@ class BattleService
 
   # Validate the given company id matches a company belonging to the player and ruleset
   def validate_company(company_id, ruleset)
-    company = Company.find(company_id)
+    company = ActiveCompany.find(company_id)
     raise BattleValidationError.new "Invalid Company id #{company_id}" unless company.present?
     raise BattleValidationError.new "Company #{company_id} has mismatched ruleset, expected #{ruleset.id} got #{company.ruleset.id}" unless company.ruleset == ruleset
     company

--- a/app/services/company_bonuses_service.rb
+++ b/app/services/company_bonuses_service.rb
@@ -12,7 +12,7 @@ class CompanyBonusesService
   end
 
   def purchase_resource_bonus(resource)
-    company = Company.includes(:ruleset, company_resource_bonuses: :resource_bonus).find_by(id: @company_id, player: @player)
+    company = ActiveCompany.includes(:ruleset, company_resource_bonuses: :resource_bonus).find_by(id: @company_id, player: @player)
 
     # Validate company belongs to player
     validate_can_update_company(company)
@@ -33,7 +33,7 @@ class CompanyBonusesService
   end
 
   def refund_resource_bonus(resource)
-    company = Company.includes(:ruleset, company_resource_bonuses: :resource_bonus).find_by(id: @company_id, player: @player)
+    company = ActiveCompany.includes(:ruleset, company_resource_bonuses: :resource_bonus).find_by(id: @company_id, player: @player)
 
     # Validate company belongs to player
     validate_can_update_company(company)

--- a/app/services/company_service.rb
+++ b/app/services/company_service.rb
@@ -27,7 +27,7 @@ class CompanyService
 
     ActiveRecord::Base.transaction do
       # Create Company entity
-      new_company = Company.create!(name: name,
+      new_company = ActiveCompany.create!(name: name,
                                     player: @player,
                                     doctrine: doctrine,
                                     faction: doctrine.faction,

--- a/db/migrate/20211120220814_create_companies.rb
+++ b/db/migrate/20211120220814_create_companies.rb
@@ -2,6 +2,7 @@ class CreateCompanies < ActiveRecord::Migration[6.1]
   def change
     create_table :companies do |t|
       t.string :name, comment: "Company name"
+      t.string :type, comment: "Company type"
       t.references :player, index: true, foreign_key: true, null: false
       t.references :doctrine, index: true, foreign_key: true, null: false
       t.references :faction, index: true, foreign_key: true, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -175,6 +175,7 @@ ActiveRecord::Schema.define(version: 2024_01_22_011211) do
 
   create_table "companies", force: :cascade do |t|
     t.string "name", comment: "Company name"
+    t.string "type", comment: "Company type"
     t.bigint "player_id", null: false
     t.bigint "doctrine_id", null: false
     t.bigint "faction_id", null: false

--- a/spec/factories/active_company.rb
+++ b/spec/factories/active_company.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :active_company do
+    association :faction
+    association :doctrine
+    association :player
+    association :ruleset
+    name { "Company name" }
+    vps_earned { 0 }
+    vps_current { 0 }
+    pop { 0 }
+    man { 7000 }
+    mun { 1600 }
+    fuel { 1400 }
+  end
+end
+

--- a/spec/factories/snapshot_company.rb
+++ b/spec/factories/snapshot_company.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :snapshot_company do
+    association :faction
+    association :doctrine
+    association :player
+    association :ruleset
+    name { "Company name" }
+    vps_earned { 0 }
+    vps_current { 0 }
+    pop { 0 }
+    man { 7000 }
+    mun { 1600 }
+    fuel { 1400 }
+  end
+end
+

--- a/spec/models/active_company_spec.rb
+++ b/spec/models/active_company_spec.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: companies
+#
+#  id                                       :bigint           not null, primary key
+#  fuel(Fuel available to this company)     :integer          default(0)
+#  man(Manpower available to this company)  :integer          default(0)
+#  mun(Munitions available to this company) :integer          default(0)
+#  name(Company name)                       :string
+#  pop(Population cost of this company)     :integer          default(0)
+#  type(Company type)                       :string
+#  vps_current(VPs available to spend)      :integer          default(0), not null
+#  vps_earned(VPs earned by this company)   :integer          default(0), not null
+#  created_at                               :datetime         not null
+#  updated_at                               :datetime         not null
+#  doctrine_id                              :bigint           not null
+#  faction_id                               :bigint           not null
+#  player_id                                :bigint           not null
+#  ruleset_id                               :bigint           not null
+#
+# Indexes
+#
+#  index_companies_on_doctrine_id  (doctrine_id)
+#  index_companies_on_faction_id   (faction_id)
+#  index_companies_on_player_id    (player_id)
+#  index_companies_on_ruleset_id   (ruleset_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (doctrine_id => doctrines.id)
+#  fk_rails_...  (faction_id => factions.id)
+#  fk_rails_...  (player_id => players.id)
+#  fk_rails_...  (ruleset_id => rulesets.id)
+#
+require "rails_helper"
+
+RSpec.describe ActiveCompany, type: :model do
+  let!(:company) { create :active_company }
+end

--- a/spec/models/snapshot_company_spec.rb
+++ b/spec/models/snapshot_company_spec.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: companies
+#
+#  id                                       :bigint           not null, primary key
+#  fuel(Fuel available to this company)     :integer          default(0)
+#  man(Manpower available to this company)  :integer          default(0)
+#  mun(Munitions available to this company) :integer          default(0)
+#  name(Company name)                       :string
+#  pop(Population cost of this company)     :integer          default(0)
+#  type(Company type)                       :string
+#  vps_current(VPs available to spend)      :integer          default(0), not null
+#  vps_earned(VPs earned by this company)   :integer          default(0), not null
+#  created_at                               :datetime         not null
+#  updated_at                               :datetime         not null
+#  doctrine_id                              :bigint           not null
+#  faction_id                               :bigint           not null
+#  player_id                                :bigint           not null
+#  ruleset_id                               :bigint           not null
+#
+# Indexes
+#
+#  index_companies_on_doctrine_id  (doctrine_id)
+#  index_companies_on_faction_id   (faction_id)
+#  index_companies_on_player_id    (player_id)
+#  index_companies_on_ruleset_id   (ruleset_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (doctrine_id => doctrines.id)
+#  fk_rails_...  (faction_id => factions.id)
+#  fk_rails_...  (player_id => players.id)
+#  fk_rails_...  (ruleset_id => rulesets.id)
+#
+require "rails_helper"
+
+RSpec.describe SnapshotCompany, type: :model do
+  let!(:company) { create :snapshot_company }
+end

--- a/spec/services/battle_report_service_spec.rb
+++ b/spec/services/battle_report_service_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe BattleReportService do
   let(:unit1) { create :unit }
   let(:unit2) { create :unit }
 
-  let!(:company1) { create :company, player: player1, ruleset: ruleset }
-  let!(:company2) { create :company, player: player2, ruleset: ruleset }
+  let!(:company1) { create :active_company, player: player1, ruleset: ruleset }
+  let!(:company2) { create :active_company, player: player2, ruleset: ruleset }
   let!(:available_unit1) { create :available_unit, unit: unit1, company: company1, available: 10, resupply: 5, resupply_max: 10 }
   let!(:available_unit2) { create :available_unit, unit: unit2, company: company2, available: 80, resupply: 10, resupply_max: 99 }
   let!(:squad11) { create :squad, available_unit: available_unit1, company: company1 }
@@ -457,8 +457,8 @@ RSpec.describe BattleReportService do
   end
 
   describe "#add_company_vps" do
-    let!(:company3) { create :company, player: player1, ruleset: ruleset }
-    let!(:company4) { create :company, player: player2, ruleset: ruleset }
+    let!(:company3) { create :active_company, player: player1, ruleset: ruleset }
+    let!(:company4) { create :active_company, player: player2, ruleset: ruleset }
 
     context "when all companies have less than max_vps VPs" do
       it "updates all company vps_earned" do

--- a/spec/services/battle_service_spec.rb
+++ b/spec/services/battle_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BattleService do
   let(:doctrine2) { create :doctrine, faction: faction2 }
   let(:size) { 1 }
   let(:unit1) { create :unit }
-  let(:company) { create :company, player: player, ruleset: ruleset, faction: faction1, doctrine: doctrine1 }
+  let(:company) { create :active_company, player: player, ruleset: ruleset, faction: faction1, doctrine: doctrine1 }
 
   before do
     available_unit = create :available_unit, company: company, unit: unit1, pop: 10

--- a/spec/services/company_bonuses_service_spec.rb
+++ b/spec/services/company_bonuses_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CompanyBonusesService do
   let!(:man_rb) { create :resource_bonus, resource: "man", man: 100, mun: -10, fuel: -15, ruleset: ruleset }
   let!(:mun_rb) { create :resource_bonus, resource: "mun", man: -50, mun: 40, fuel: -10, ruleset: ruleset }
   let!(:fuel_rb) { create :resource_bonus, resource: "fuel", man: -60, mun: -20, fuel: 50, ruleset: ruleset }
-  let!(:company) { create :company, player: player, ruleset: ruleset }
+  let!(:company) { create :active_company, player: player, ruleset: ruleset }
   let(:company_id) { company.id }
 
   subject(:instance) { described_class.new(company_id, player) }

--- a/spec/services/company_unlock_service_spec.rb
+++ b/spec/services/company_unlock_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CompanyUnlockService do
   let(:starting_man) { ruleset.starting_man }
   let(:starting_mun) { ruleset.starting_mun }
   let(:starting_fuel) { ruleset.starting_fuel }
-  let!(:company) { create :company, doctrine: doctrine, faction: faction, ruleset: ruleset, vps_current: vps_current, man: starting_man, mun: starting_mun, fuel: starting_fuel }
+  let!(:company) { create :active_company, doctrine: doctrine, faction: faction, ruleset: ruleset, vps_current: vps_current, man: starting_man, mun: starting_mun, fuel: starting_fuel }
   let!(:unlock1) { create :unlock }
   let!(:unlock2) { create :unlock }
   let(:vp_cost) { 3 }


### PR DESCRIPTION
In preparation for introducing company snapshots, we should create a distinction between active companies, which are actively edited and used in battles, and snapshot companies which should be static.