### PR TITLE
Add ability for admins to kick players from lobbies

### DIFF
--- a/app/api/omg/battles.rb
+++ b/app/api/omg/battles.rb
@@ -98,6 +98,17 @@ module OMG
           service.unready_player(declared_params[:battleId])
         end
 
+        # Kick player from battle
+        desc "Admin kick player from lobby"
+        params do
+          requires :battleId, type: Integer, desc: "Battle id to kick from"
+          requires :kickPlayerId, type: Integer, desc: "Player id to kick"
+        end
+        post 'kick' do
+          service = BattleService.new(current_player)
+          service.kick_player(declared_params[:battleId], declared_params[:kickPlayerId])
+        end
+
         # Abandon a 'generating', 'ingame', 'reporting'? Battle
         desc "Mark a player as abandoned in a battle"
         params do

--- a/app/javascript/features/lobby/display/BattleCardPlayer.jsx
+++ b/app/javascript/features/lobby/display/BattleCardPlayer.jsx
@@ -3,9 +3,10 @@ import { Box, Button, createTheme, Popover, Stack, Typography } from "@mui/mater
 import { makeStyles } from "@mui/styles";
 import CheckIcon from '@mui/icons-material/Check';
 import LogoutIcon from '@mui/icons-material/Logout';
+import CancelIcon from '@mui/icons-material/Cancel';
 import { TeamBalanceIcon } from '../../resources/TeamBalanceIcon';
 import { useDispatch, useSelector } from "react-redux";
-import { abandonBattle, leaveBattle, readyPlayer, selectIsPending, unreadyPlayer } from "../lobbySlice";
+import { abandonBattle, leaveBattle, readyPlayer, selectIsPending, unreadyPlayer, kickPlayer } from "../lobbySlice";
 import { selectIsAuthed, selectPlayer, selectPlayerCurrentBattleId } from "../../player/playerSlice";
 import { ALLIED_SIDE, doctrineImgMapping } from "../../../constants/doctrines";
 import { JoinBattlePopover } from "./JoinBattlePopover";
@@ -41,6 +42,9 @@ const useStyles = makeStyles(theme => ({
   },
   joinText: {
     cursor: 'pointer'
+  },
+  PlayerElo: {
+    marginLeft: '0.25rem'
   },
   selfPlayerName: {
     overflowX: 'clip',
@@ -111,6 +115,12 @@ export const BattleCardPlayer = ({
     }
   }
 
+  const handleKickClick = () => {
+    if (isAdmin) {
+      dispatch(kickPlayer({ battleId: battleId, playerId: player.id, kickPlayerId: playerId }))
+    }
+  }
+
   const handleAbandonClick = () => {
     dispatch(abandonBattle({ battleId, playerId }))
   }
@@ -167,12 +177,14 @@ export const BattleCardPlayer = ({
           <Box className={classes.wrapperRow}>
             <TeamBalanceIcon team={teamBalance} isFull={isFull}/>
             <Typography variant="h5" color="secondary" className={classes.selfPlayerName}>{playerName}</Typography>
+            {isAdmin ? <Typography variant="h5" color="darkgrey" theme={eloTheme}
+                                 className={classes.PlayerElo}> <sup>{playerElo}</sup></Typography> : null}
             {readyContent}
             {leavable ? <LogoutIcon className={classes.clickableIcon} color="error" onClick={leaveGame}/> : ""}
+            
+            {isAdmin ? <CancelIcon className={classes.clickableIcon} color="error" onClick={handleKickClick}/> : null}
           </Box>
-
-          {isAdmin ? <Typography variant="h6" color="darkgrey" theme={eloTheme}
-                                 className={classes.PlayerElo}>{playerElo}</Typography> : null}
+          
 
         </Stack>
         {side === ALLIED_SIDE ? doctrineIcon : null}
@@ -195,10 +207,13 @@ export const BattleCardPlayer = ({
           <Box className={classes.wrapperRow}>
             <TeamBalanceIcon team={teamBalance} isFull={isFull}/>
             <Typography variant="h5" className={classes.playerName}> {playerName}</Typography>
+            {isAdmin ? <Typography variant="h5" color="darkgrey" theme={eloTheme}
+                                 className={classes.PlayerElo}><sup>{playerElo}</sup></Typography> : null}
             {readyContent}
+            
+            {isAdmin ? <CancelIcon className={classes.clickableIcon} color="error" onClick={handleKickClick}/> : null}
           </Box>
-          {isAdmin ? <Typography variant="h6" color="darkgrey" theme={eloTheme}
-                                 className={classes.PlayerElo}>{playerElo}</Typography> : null}
+
         </Stack>
         {side === ALLIED_SIDE ? doctrineIcon : null}
       </>

--- a/app/javascript/features/lobby/display/BattleCardPlayer.jsx
+++ b/app/javascript/features/lobby/display/BattleCardPlayer.jsx
@@ -117,7 +117,7 @@ export const BattleCardPlayer = ({
 
   const handleKickClick = () => {
     if (isAdmin) {
-      dispatch(kickPlayer({ battleId: battleId, playerId: player.id, kickPlayerId: playerId }))
+      dispatch(kickPlayer({ battleId: battleId, kickPlayerId: playerId }))
     }
   }
 

--- a/app/javascript/features/lobby/lobbySlice.js
+++ b/app/javascript/features/lobby/lobbySlice.js
@@ -67,6 +67,18 @@ export const leaveBattle = createAsyncThunk(
   }
 )
 
+export const kickPlayer = createAsyncThunk(
+  "lobby/kickPlayer",
+  async ({ battleId, playerId, kickPlayerId }, { _, rejectWithValue }) => {
+    try {
+      const response = await axios.post("/battles/player/kick", { battleId, playerId, kickPlayerId })
+      return response.data
+    } catch (err) {
+      return rejectWithValue(err.response.data)
+    }
+  }
+)
+
 export const readyPlayer = createAsyncThunk(
   "lobby/readyPlayer",
   async ({ battleId, playerId }, { _, rejectWithValue }) => {

--- a/app/javascript/features/lobby/lobbySlice.js
+++ b/app/javascript/features/lobby/lobbySlice.js
@@ -69,9 +69,9 @@ export const leaveBattle = createAsyncThunk(
 
 export const kickPlayer = createAsyncThunk(
   "lobby/kickPlayer",
-  async ({ battleId, playerId, kickPlayerId }, { _, rejectWithValue }) => {
+  async ({ battleId, kickPlayerId }, { _, rejectWithValue }) => {
     try {
-      const response = await axios.post("/battles/player/kick", { battleId, playerId, kickPlayerId })
+      const response = await axios.post("/battles/player/kick", { battleId, kickPlayerId })
       return response.data
     } catch (err) {
       return rejectWithValue(err.response.data)


### PR DESCRIPTION
Deployed to: https://omgmod-ruby-e67cfe8ae18c.herokuapp.com/

Adds kick player button for admins

#TODO Figure out how we should be creating admins, currently just been manually swapping role, same way as discord id's currently?

![image](https://github.com/mma127/omg_rails/assets/1526733/8719365b-2c0e-475b-8a93-cac479f0b592)
