### PR TITLE
Reconcile over resupply of availability for surviving squads

### DIFF
--- a/spec/services/battle_report_service_spec.rb
+++ b/spec/services/battle_report_service_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe BattleReportService do
 
         it "updates availability" do
           process_report
-          expect(available_unit1.reload.available).to eq 8 # company max of 2 - 2 squads
+          expect(available_unit1.reload.available).to eq 0 # company max of 2 - 2 squads
           expect(available_unit2.reload.available).to eq 89
         end
       end

--- a/spec/services/battle_report_service_spec.rb
+++ b/spec/services/battle_report_service_spec.rb
@@ -442,6 +442,18 @@ RSpec.describe BattleReportService do
     end
   end
 
+  describe "#reconcile_company_unit_available" do
+    # Simulates post-resupply update of availability given 2 surviving squads of this available unit
+    let!(:available_unit1) { create :available_unit, unit: unit1, company: company1, available: 1, resupply: 1, resupply_max: 1, company_max: 2 }
+
+    subject { instance.send(:reconcile_company_unit_available, company1) }
+
+    it "sets available to 0" do
+      subject
+      expect(available_unit1.reload.available).to eq 0
+    end
+  end
+
   describe "#recalculate_company_resources" do
     it "updates the company resources" do
       instance.send(:recalculate_company_resources)


### PR DESCRIPTION
If an available unit has 1 resupply, 1 company max, and reports with 1 surviving squad, the current logic will 
1. Apply resupply to available, resulting in 1 available
2. Not change available to account for the surviving squad (since we only do that for dead squad rebuilds)

This change adds a further step to compare count of squads of the available unit + available count and compares against the company max. If exceeds, reduce available as necessary until 0.

NOTE: this allows for the possibility of overages because we do not delete squads. Monitor in case this is also needed.