### PR TITLE
Player rating elo override for balancing

### DIFF
--- a/app/models/battle_player.rb
+++ b/app/models/battle_player.rb
@@ -47,7 +47,7 @@ class BattlePlayer < ApplicationRecord
   end
 
   def player_elo
-    player.player_rating.elo
+    player.player_rating.elo_effective
   end
 
   def win?

--- a/app/models/player_rating.rb
+++ b/app/models/player_rating.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                 :bigint           not null, primary key
 #  elo(trueskill mu normalized between 1000 and 2000) :integer
+#  elo_override(Override elo to provide a handicap)   :integer
 #  last_played(last played match)                     :date
 #  losses(losses to date)                             :integer          default(0)
 #  mu(trueskill mu)                                   :float
@@ -39,6 +40,14 @@ class PlayerRating < ApplicationRecord
 
   def self.for_new_player(player)
     PlayerRating.create!(player: player, elo: DEFAULT_ELO, mu: DEFAULT_MU, sigma: DEFAULT_SIGMA, last_played: nil)
+  end
+
+  def elo_effective
+    if elo_override.present?
+      elo_override
+    else
+      elo
+    end
   end
 
   def weeks_since_last_played(now = DateTime.now)

--- a/app/services/ratings/balance_service.rb
+++ b/app/services/ratings/balance_service.rb
@@ -46,7 +46,7 @@ module Ratings
     def average_elo(battle_players)
       return 0 unless battle_players.size.positive?
 
-      sum = battle_players.sum { |bp| bp.player.player_rating.elo }
+      sum = battle_players.sum { |bp| bp.player_elo }
 
       sum / battle_players.size
     end

--- a/db/migrate/20240328013430_add_elo_override_to_player_rating.rb
+++ b/db/migrate/20240328013430_add_elo_override_to_player_rating.rb
@@ -1,0 +1,5 @@
+class AddEloOverrideToPlayerRating < ActiveRecord::Migration[6.1]
+  def change
+    add_column :player_ratings, :elo_override, :integer, comment: "Override elo to provide a handicap"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_17_202440) do
+ActiveRecord::Schema.define(version: 2024_03_28_013430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -385,6 +385,7 @@ ActiveRecord::Schema.define(version: 2024_03_17_202440) do
     t.integer "losses", default: 0, comment: "losses to date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "elo_override", comment: "Override elo to provide a handicap"
     t.index ["mu"], name: "index_player_ratings_on_mu"
     t.index ["player_id"], name: "index_player_ratings_on_player_id"
   end

--- a/spec/models/player_rating_spec.rb
+++ b/spec/models/player_rating_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                                                 :bigint           not null, primary key
 #  elo(trueskill mu normalized between 1000 and 2000) :integer
+#  elo_override(Override elo to provide a handicap)   :integer
 #  last_played(last played match)                     :date
 #  losses(losses to date)                             :integer          default(0)
 #  mu(trueskill mu)                                   :float
@@ -32,6 +33,25 @@ RSpec.describe PlayerRating, type: :model do
 
   describe 'associations' do
     it { should belong_to(:player) }
+  end
+
+  describe "#elo_effective" do
+    context "when elo_override is null" do
+      it "returns elo" do
+        expect(player_rating.elo_effective).to eq player_rating.elo
+      end
+    end
+
+    context "when elo_override is set" do
+      let(:elo_override) { 1250 }
+      before do
+        player_rating.update!(elo_override: elo_override)
+      end
+
+      it "returns elo_override" do
+        expect(player_rating.elo_effective).to eq elo_override
+      end
+    end
   end
 
   describe "#from_historical" do

--- a/spec/services/ratings/balance_service_spec.rb
+++ b/spec/services/ratings/balance_service_spec.rb
@@ -130,6 +130,36 @@ RSpec.describe Ratings::BalanceService do
         end
       end
 
+      context "when there is zero elo diff but elo_overrides" do
+        let(:elo1) { 1800 }
+        let(:elo2) { 1800 }
+        let(:elo3) { 1200 }
+        let(:elo4) { 1200 }
+
+        before do
+          player2_rating.update!(elo_override: 1900)
+          player4_rating.update!(elo_override: 1700)
+        end
+
+        it "returns balanced teams" do
+          elo_diff, team1, team2 = subject
+
+          expect(elo_diff).to eq 200
+          expect(team1).to match_array [bp1, bp4]
+          expect(team2).to match_array [bp2, bp3]
+        end
+
+        it "persists the results" do
+          subject
+
+          expect(battle.reload.elo_diff).to eq 200
+          expect(bp1.reload.team_balance).to eq 1
+          expect(bp2.reload.team_balance).to eq 2
+          expect(bp3.reload.team_balance).to eq 2
+          expect(bp4.reload.team_balance).to eq 1
+        end
+      end
+
       context "when there is non-zero elo diff" do
         let(:elo1) { 1800 }
         let(:elo2) { 1100 }


### PR DESCRIPTION
Custom elo override for battle balancing only. 
Historical data will still use the player's normal elo