### PR TITLE
Service to create ruleset from seed csv

### DIFF
--- a/app/services/seeds/ruleset_service.rb
+++ b/app/services/seeds/ruleset_service.rb
@@ -1,0 +1,42 @@
+require 'csv'
+
+module Seeds
+  class RulesetService < ApplicationService
+    FILENAME = 'lib/assets/rulesets.csv'.freeze
+
+    def self.create_new_ruleset(ruleset_type, name)
+      Ruleset.transaction do
+        new_ruleset_csv_row = get_ruleset_csv_row(ruleset_type)
+        raise ArgumentError.new "No row found matching ruleset type #{ruleset_type} in seed file [#{FILENAME}]" if new_ruleset_csv_row.blank?
+
+        active_ruleset = get_active_ruleset(ruleset_type)
+        if active_ruleset
+          active_ruleset.update!(is_active: false)
+        end
+
+        Ruleset.create!(name: name,
+                        ruleset_type: ruleset_type,
+                        is_active: true,
+                        description: new_ruleset_csv_row["description"],
+                        starting_man: new_ruleset_csv_row["starting_man"],
+                        starting_mun: new_ruleset_csv_row["starting_mun"],
+                        starting_fuel: new_ruleset_csv_row["starting_fuel"],
+                        starting_vps: new_ruleset_csv_row["starting_vps"],
+                        max_vps: new_ruleset_csv_row["max_vps"],
+                        max_resource_bonuses: new_ruleset_csv_row["max_resource_bonuses"]
+        )
+      end
+    end
+
+    private
+
+    def self.get_ruleset_csv_row(ruleset_type)
+      csv = CSV.read(FILENAME, headers: true)
+      csv.find { |row| row["type"] == ruleset_type }
+    end
+
+    def self.get_active_ruleset(ruleset_type)
+      Ruleset.find_by(is_active: true, ruleset_type: ruleset_type)
+    end
+  end
+end

--- a/db/seeds/rulesets.seeds.rb
+++ b/db/seeds/rulesets.seeds.rb
@@ -1,10 +1,1 @@
-Ruleset.create!(name: "War 1",
-                ruleset_type: Ruleset.ruleset_types[:war],
-                is_active: true,
-                description: "OMG standard WAR format",
-                starting_man: 9000,
-                starting_mun: 1900,
-                starting_fuel: 1400,
-                starting_vps: 20, # FIXME: restore to 15
-                max_vps: 25,
-                max_resource_bonuses: 5)
+Seeds::RulesetService.create_new_ruleset(Ruleset.ruleset_types[:war], "War 1")

--- a/lib/assets/rulesets.csv
+++ b/lib/assets/rulesets.csv
@@ -1,0 +1,2 @@
+type,description,starting_man,starting_mun,starting_fuel,starting_vps,max_vps,max_resource_bonuses
+war,"OMG standard WAR format",9000,1900,1400,20,25,5

--- a/spec/services/seeds/ruleset_service_spec.rb
+++ b/spec/services/seeds/ruleset_service_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Seeds::RulesetService do
+  let(:name) { "new war" }
+  let(:ruleset_type) { Ruleset.ruleset_types[:war] }
+
+  describe "#create_new_ruleset" do
+    subject { described_class.create_new_ruleset(ruleset_type, name) }
+
+    context "when there are no pre-existing rulesets" do
+      it "creates a new ruleset" do
+        expect(Ruleset.count).to eq 0
+        expect { subject }.to change { Ruleset.count }.by 1
+      end
+
+      it "creates an active ruleset with the given name" do
+        new_ruleset = subject
+        expect(new_ruleset.is_active).to be true
+        expect(new_ruleset.ruleset_type).to eq ruleset_type
+        expect(new_ruleset.name).to eq name
+      end
+    end
+
+    context "when there are pre-existing rulesets" do
+      let!(:existing_ruleset) { create :ruleset }
+
+      before do
+        create :ruleset, is_active: false
+        create :ruleset, is_active: false
+      end
+
+      it "creates a new ruleset" do
+        expect(Ruleset.count).to eq 3
+        expect { subject }.to change { Ruleset.count }.by 1
+      end
+
+      it "creates an active ruleset with the given name" do
+        new_ruleset = subject
+        expect(new_ruleset.is_active).to be true
+        expect(new_ruleset.ruleset_type).to eq ruleset_type
+        expect(new_ruleset.name).to eq name
+      end
+
+      it "marks the formerly active ruleset as not active" do
+        subject
+        expect(existing_ruleset.reload.is_active).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to reuse the seed csvs for both seeding an empty db and for creating a war reset, so we need to move all seed operations to services. Ruleset is the last one that hasn't been migrated