### PR TITLE
Fix dupe offmap when creating new ruleset

### DIFF
--- a/app/services/available_offmap_service.rb
+++ b/app/services/available_offmap_service.rb
@@ -6,6 +6,7 @@ class AvailableOffmapService
     @player = company.player
     @faction = company.faction
     @doctrine = company.doctrine
+    @ruleset = company.ruleset
   end
 
   # Given a new company, determine the available offmaps for that company
@@ -50,7 +51,7 @@ class AvailableOffmapService
   end
 
   def get_enabled_offmap_hash(restriction)
-    EnabledOffmap.where(restriction: restriction).index_by(&:offmap_id)
+    EnabledOffmap.where(restriction: restriction, ruleset: @ruleset).index_by(&:offmap_id)
   end
 
   def merge_allowed_offmaps(existing_offmaps_hash, restricted_offmaps_hash)

--- a/app/services/available_unit_service.rb
+++ b/app/services/available_unit_service.rb
@@ -8,6 +8,7 @@ class AvailableUnitService
     @player = company.player
     @faction = company.faction
     @doctrine = company.doctrine
+    @ruleset = company.ruleset
   end
 
   # Given a new company, determine the available units for that company
@@ -128,11 +129,11 @@ class AvailableUnitService
   end
 
   def get_enabled_unit_hash(restriction)
-    EnabledUnit.where(restriction: restriction, ruleset: @company.ruleset).index_by(&:unit_id)
+    EnabledUnit.where(restriction: restriction, ruleset: @ruleset).index_by(&:unit_id)
   end
 
   def get_disabled_unit_hash(restriction)
-    DisabledUnit.where(restriction: restriction, ruleset: @company.ruleset).index_by(&:unit_id)
+    DisabledUnit.where(restriction: restriction, ruleset: @ruleset).index_by(&:unit_id)
   end
 
   def merge_allowed_units(existing_units_hash, restricted_units_hash)
@@ -185,13 +186,13 @@ class AvailableUnitService
   end
 
   def get_unmodified_base_available_unit(unit, du_u_restrictions)
-    du_u_enabled_unit = EnabledUnit.find_by(restriction: du_u_restrictions, unit: unit, ruleset: @company.ruleset)
+    du_u_enabled_unit = EnabledUnit.find_by(restriction: du_u_restrictions, unit: unit, ruleset: @ruleset)
     return instantiate_base_available_unit(du_u_enabled_unit) if du_u_enabled_unit.present?
 
-    doctrine_enabled_unit = EnabledUnit.find_by(restriction: @doctrine.restriction, unit: unit, ruleset: @company.ruleset)
+    doctrine_enabled_unit = EnabledUnit.find_by(restriction: @doctrine.restriction, unit: unit, ruleset: @ruleset)
     return instantiate_base_available_unit(doctrine_enabled_unit) if doctrine_enabled_unit.present?
 
-    faction_enabled_unit = EnabledUnit.find_by(restriction: @faction.restriction, unit: unit, ruleset: @company.ruleset)
+    faction_enabled_unit = EnabledUnit.find_by(restriction: @faction.restriction, unit: unit, ruleset: @ruleset)
     return instantiate_base_available_unit(faction_enabled_unit) if faction_enabled_unit.present?
 
     raise EnabledUnitNotFoundError.new("Could not determine an unmodified EnabledUnit for unit #{unit.id} in company #{@company.id}")

--- a/app/services/available_upgrade_service.rb
+++ b/app/services/available_upgrade_service.rb
@@ -10,6 +10,7 @@ class AvailableUpgradeService
     @player = company.player
     @faction = company.faction
     @doctrine = company.doctrine
+    @ruleset = company.ruleset
   end
 
   # Given a new company, determine the available upgrades for the company
@@ -178,7 +179,7 @@ class AvailableUpgradeService
   #   -> unit_id
   #     -> enabled_upgrade (this can be replaced when merging a more specific upgrade hash ie, doctrine upgrade hash)
   def get_enabled_upgrade_hash(restriction)
-    enabled_upgrades = EnabledUpgrade.includes(:units).where(restriction: restriction, ruleset: @company.ruleset)
+    enabled_upgrades = EnabledUpgrade.includes(:units).where(restriction: restriction, ruleset: @ruleset)
     build_enabled_upgrades_hash(enabled_upgrades)
   end
 
@@ -196,7 +197,7 @@ class AvailableUpgradeService
   # Creates hash of
   # upgrade_id -> Set of unit_id
   def get_disabled_upgrade_hash(restriction)
-    disabled_upgrades = DisabledUpgrade.includes(:units).where(restriction: restriction, ruleset: @company.ruleset)
+    disabled_upgrades = DisabledUpgrade.includes(:units).where(restriction: restriction, ruleset: @ruleset)
     build_disabled_upgrades_hash(disabled_upgrades)
   end
 
@@ -348,7 +349,7 @@ class AvailableUpgradeService
 
   def find_enabled_upgrade(restrictions, upgrade, unit_id)
     EnabledUpgrade.joins(:restriction_upgrade_units)
-                  .find_by(restriction: restrictions, upgrade: upgrade, ruleset: @company.ruleset,
+                  .find_by(restriction: restrictions, upgrade: upgrade, ruleset: @ruleset,
                            restriction_upgrade_units: { unit_id: unit_id })
   end
 

--- a/app/services/company_unlock_service.rb
+++ b/app/services/company_unlock_service.rb
@@ -3,6 +3,7 @@ class CompanyUnlockService
 
   def initialize(company)
     @company = company
+    @ruleset = company.ruleset
   end
 
   def purchase_doctrine_unlock(doctrine_unlock)
@@ -20,7 +21,7 @@ class CompanyUnlockService
     # Get Restrictions for the doctrineUnlock and associated unlock
     du_restriction = doctrine_unlock.restriction
     u_restriction = unlock.restriction
-    restriction_params = { restriction: [du_restriction, u_restriction] }
+    restriction_params = { restriction: [du_restriction, u_restriction], ruleset: @ruleset }
 
     # Get EnabledUnits for those restrictions
     enabled_units = EnabledUnit.includes(:unit).where(restriction_params)
@@ -125,7 +126,7 @@ class CompanyUnlockService
     # Get Restrictions for the DoctrineUnlock and Unlock
     du_restriction = doctrine_unlock.restriction
     u_restriction = unlock.restriction
-    restriction_params = { restriction: [du_restriction, u_restriction] }
+    restriction_params = { restriction: [du_restriction, u_restriction], ruleset: @ruleset }
 
     # Get EnabledUnits for those restrictions
     previously_enabled_units = EnabledUnit.includes(:unit).where(restriction_params)

--- a/lib/tasks/reset_war.rake
+++ b/lib/tasks/reset_war.rake
@@ -1,0 +1,3 @@
+task reset_war: :environment do
+  WarResetService.reset_ruleset(Ruleset.ruleset_types[:war], "May 2024")
+end

--- a/spec/services/available_upgrade_service_spec.rb
+++ b/spec/services/available_upgrade_service_spec.rb
@@ -103,7 +103,76 @@ RSpec.describe AvailableUpgradeService do
       expect(au1.fuel).to eq 50
       expect(au1.uses).to eq 0
     end
+    
+    context "when there is a previous ruleset" do
+      before do
+        old_ruleset = create :ruleset, is_active: false
+        old_enabled_upgrade1 = create :enabled_upgrade, upgrade: upgrade1, man: 0, mun: 35, fuel: 0, pop: 0, uses: 2, restriction: restriction_faction, ruleset: old_ruleset
+        old_enabled_upgrade1_doctrine = create :enabled_upgrade, upgrade: upgrade1, man: 0, mun: 40, fuel: 0, pop: 0, uses: 3, restriction: restriction_doctrine1, ruleset: old_ruleset
+        old_enabled_upgrade2 = create :enabled_upgrade, upgrade: upgrade2, man: 100, mun: 35, fuel: 0, pop: 2, uses: 0, restriction: restriction_faction, ruleset: old_ruleset
+        old_enabled_upgrade3 = create :enabled_upgrade, upgrade: upgrade3, man: 0, mun: 0, fuel: 50, pop: 0, uses: 0, restriction: restriction_doctrine1, ruleset: old_ruleset
+        old_enabled_upgrade4 = create :enabled_upgrade, upgrade: upgrade4, restriction: restriction_faction2, ruleset: old_ruleset
+        old_disabled_upgrade2 = create :disabled_upgrade, upgrade: upgrade2, restriction: restriction_doctrine2, ruleset: old_ruleset
+        create :restriction_upgrade_unit, restriction_upgrade: old_enabled_upgrade1, unit: unit1
+        create :restriction_upgrade_unit, restriction_upgrade: old_enabled_upgrade1, unit: unit2
+        create :restriction_upgrade_unit, restriction_upgrade: old_enabled_upgrade1_doctrine, unit: unit1
+        create :restriction_upgrade_unit, restriction_upgrade: old_enabled_upgrade2, unit: unit2
+        create :restriction_upgrade_unit, restriction_upgrade: old_enabled_upgrade2, unit: unit3
+        create :restriction_upgrade_unit, restriction_upgrade: old_enabled_upgrade3, unit: unit3
+        create :restriction_upgrade_unit, restriction_upgrade: old_enabled_upgrade4, unit: unit4
+        create :restriction_upgrade_unit, restriction_upgrade: old_disabled_upgrade2, unit: unit2
+      end
+      it "creates the correct number of AvailableUpgrades" do
+        expect { subject }.to change { AvailableUpgrade.count }.by 5
 
+        available_upgrades = AvailableUpgrade.where(company: company)
+        expect(available_upgrades.count).to eq 5
+        expect(available_upgrades.pluck(:upgrade_id))
+          .to match_array [upgrade1.id, upgrade1.id, upgrade2.id, upgrade2.id, upgrade3.id]
+      end
+
+      it "creates the correct AvailableUpgrades for upgrade1" do
+        subject
+        au1 = AvailableUpgrade.find_by(company: company, upgrade: upgrade1, unit: unit1)
+        expect(au1.pop).to eq 0
+        expect(au1.man).to eq 0
+        expect(au1.mun).to eq 40
+        expect(au1.fuel).to eq 0
+        expect(au1.uses).to eq 3
+        au2 = AvailableUpgrade.find_by(company: company, upgrade: upgrade1, unit: unit2)
+        expect(au2.pop).to eq 0
+        expect(au2.man).to eq 0
+        expect(au2.mun).to eq 35
+        expect(au2.fuel).to eq 0
+        expect(au2.uses).to eq 2
+      end
+
+      it "creates the correct AvailableUpgrades for upgrade2" do
+        subject
+        au1 = AvailableUpgrade.find_by(company: company, upgrade: upgrade2, unit: unit2)
+        expect(au1.pop).to eq 2
+        expect(au1.man).to eq 100
+        expect(au1.mun).to eq 35
+        expect(au1.fuel).to eq 0
+        expect(au1.uses).to eq 0
+        au2 = AvailableUpgrade.find_by(company: company, upgrade: upgrade2, unit: unit3)
+        expect(au2.pop).to eq 2
+        expect(au2.man).to eq 100
+        expect(au2.mun).to eq 35
+        expect(au2.fuel).to eq 0
+        expect(au2.uses).to eq 0
+      end
+
+      it "creates the correct AvailableUpgrades for upgrade3" do
+        subject
+        au1 = AvailableUpgrade.find_by(company: company, upgrade: upgrade3, unit: unit3)
+        expect(au1.pop).to eq 0
+        expect(au1.man).to eq 0
+        expect(au1.mun).to eq 0
+        expect(au1.fuel).to eq 50
+        expect(au1.uses).to eq 0
+      end
+    end
   end
 
   describe "#add_enabled_available_upgrades" do


### PR DESCRIPTION
Since `Offmap` now has a ruleset association, there can be more than 1 `Offmap` with the same name.

`EnabledOffmap.where(restriction: restriction, ruleset: @ruleset).index_by(&:offmap_id)` will grab every duplicate `Offmap` since their ids are different.