### PR TITLE
handle edge cases for battle resize

### DIFF
--- a/app/javascript/features/lobby/display/ChangeBattleSize.jsx
+++ b/app/javascript/features/lobby/display/ChangeBattleSize.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { changeBattleSize, selectBattleById } from "../lobbySlice";
 import { makeStyles } from "@mui/styles";
 import { selectPlayer } from "../../player/playerSlice";
+import { FULL, OPEN } from "../../../constants/battles/states";
 
 const useStyles = makeStyles(theme => ({
   wrapper: {
@@ -25,6 +26,7 @@ export const ChangeBattleSize = ({ battleId }) => {
   const battle = useSelector(state => selectBattleById(state, battleId))
   const player = useSelector(selectPlayer)
   const isAdmin = player ? player.role === "admin" : false
+  const battleEditable = battle.state === OPEN || battle.state === FULL
 
   const handleReduceClick = () => {
     dispatch(changeBattleSize({ battleId, newSize: battle.size - 1 }))
@@ -40,11 +42,11 @@ export const ChangeBattleSize = ({ battleId }) => {
   return (
     <Box className={classes.wrapper}>
       <Button variant="contained" type="submit" color="secondary" size="small"
-              className={classes.readyBtn} disabled={battle.size === MIN_SIZE} onClick={handleReduceClick}>
+              className={classes.readyBtn} disabled={battle.size === MIN_SIZE || !battleEditable} onClick={handleReduceClick}>
         Reduce Size
       </Button>
       <Button variant="contained" type="submit" color="secondary" size="small"
-              className={classes.readyBtn} disabled={battle.size === MAX_SIZE} onClick={handleIncreaseClick}>
+              className={classes.readyBtn} disabled={battle.size === MAX_SIZE || !battleEditable} onClick={handleIncreaseClick}>
         Increase Size
       </Button>
     </Box>

--- a/app/services/battle_service.rb
+++ b/app/services/battle_service.rb
@@ -310,28 +310,19 @@ class BattleService
 
     # If there are more players than new size, remove players in order from most recently joined (BattlePlayer created)
     ActiveRecord::Base.transaction do
-      current_allied_count = battle.allied_battle_players.count
-      current_axis_count = battle.axis_battle_players.count
-      if current_allied_count > new_size
-        allied_count_to_remove = current_allied_count - new_size
-        remove_n_players_from_battle(battle, BattlePlayer.sides[:allied], allied_count_to_remove)
+      if battle.size < new_size
+        increase_battle_size(battle, new_size)
+      elsif battle.size > new_size
+        decrease_battle_size(battle, new_size)
+      else
+        # if same size, somehow, do nothing
       end
-      if current_axis_count > new_size
-        axis_count_to_remove = current_axis_count - new_size
-        remove_n_players_from_battle(battle, BattlePlayer.sides[:axis], axis_count_to_remove)
-      end
-      battle.update!(size: new_size)
-      update_battle_elo(battle.reload)
     end
 
     message_hash = { type: SIZE_UPDATED, battle: battle }
     # Broadcast battle update
     battle_message = Entities::BattleMessage.represent message_hash, type: :include_players
     broadcast_cable(battle_message)
-  end
-
-  def remove_n_players_from_battle(battle, side, number)
-    battle.battle_players.where(side: side).order(created_at: :desc).limit(number).destroy_all
   end
 
   private
@@ -444,5 +435,48 @@ class BattleService
     return unless battle.reload.any_players_ready?
 
     BattlePlayer.where(battle: battle, ready: true).update_all(ready: false)
+  end
+
+  def increase_battle_size(battle, new_size)
+    # check if battle was previously ready, unready players if so
+    unready_all_players(battle)
+    # Check if battle was previously full, change state to open if so
+    if battle.full?
+      battle.not_full!
+    end
+    battle.size = new_size
+    battle.save!
+  end
+
+  def decrease_battle_size(battle, new_size)
+    # it's ok if battle was full and we decrease size, don't change player ready state or battle full state
+
+    # Remove newest joined players on each side that exceed new size per side
+    current_allied_count = battle.allied_battle_players.count
+    current_axis_count = battle.axis_battle_players.count
+    if current_allied_count > new_size
+      allied_count_to_remove = current_allied_count - new_size
+      remove_n_players_from_battle(battle, BattlePlayer.sides[:allied], allied_count_to_remove)
+    end
+    if current_axis_count > new_size
+      axis_count_to_remove = current_axis_count - new_size
+      remove_n_players_from_battle(battle, BattlePlayer.sides[:axis], axis_count_to_remove)
+    end
+    battle.update!(size: new_size)
+
+    # if new set of players are all ready, generate battlefile
+    if battle.reload.players_full?
+      update_battle_elo(battle)
+      battle.full!
+      BattleNotificationService.new(battle.id).notify_battle_full
+      if battle.all_players_ready?
+        battle.ready!
+        BattlefileGenerationJob.perform_async(battle_id)
+      end
+    end
+  end
+
+  def remove_n_players_from_battle(battle, side, number)
+    battle.battle_players.where(side: side).order(created_at: :desc).limit(number).destroy_all
   end
 end


### PR DESCRIPTION
When the battle should become full, make it full
If the battle should be no longer full due to new size, change to open
Update battle player statuses as necessary