### PR TITLE
Active Unit/Upgrade/Offmap associations for Company

### DIFF
--- a/app/api/omg/companies.rb
+++ b/app/api/omg/companies.rb
@@ -51,23 +51,6 @@ module OMG
           present company, type: :with_active_battle
         end
 
-        # might not need this, combine with retrieve squads
-        desc "get all available units, offmaps for the given company"
-        params do
-          requires :id, type: Integer, desc: "Company ID"
-        end
-        get 'availability' do
-          company = ActiveCompany.includes(available_units: :unit, available_offmaps: :offmap).find_by(id: params[:id], player: current_player)
-          if company.blank?
-            error! "Could not find company #{params[:id]} for the current player", 404
-          end
-          availability = {
-            available_units: company.available_units,
-            available_offmaps: company.available_offmaps
-          }
-          present availability, with: Entities::Availability, type: :include_unit
-        end
-
         desc 'Retrieve all squads, company offmaps, available units, available offmaps for the company'
         params do
           requires :id, type: Integer, desc: "Company ID"
@@ -81,12 +64,12 @@ module OMG
 
           squads_response = {
             squads: company.squads,
-            available_units: company.available_units,
+            available_units: company.active_units,
+            available_offmaps: company.active_offmaps,
+            available_upgrades: company.active_upgrades,
             company_offmaps: company.company_offmaps,
-            available_offmaps: company.available_offmaps,
             callin_modifiers: company.callin_modifiers,
             squad_upgrades: company.squad_upgrades,
-            available_upgrades: company.available_upgrades,
             upgrades: company.upgrades
           }
           present squads_response, with: Entities::SquadsResponse, type: :include_unit

--- a/app/api/omg/helpers/company_helpers.rb
+++ b/app/api/omg/helpers/company_helpers.rb
@@ -5,14 +5,18 @@ module OMG
 
       def load_company(id, current_player)
         ActiveCompany.includes(:ruleset,
-                         { squads: [:embarked_transport, :squads_in_transport, available_unit: { unit: :transport_allowed_units }],
-                           available_units: { unit: [:transport_allowed_units, :unit_vet] },
-                           available_offmaps: :offmap,
-                           company_offmaps: :offmap,
-                           company_callin_modifiers: :callin_modifier,
-                           squad_upgrades: :squad,
-                           available_upgrades: :upgrade })
-               .find_by(id: id, player: current_player)
+                               :callin_modifiers,
+                               :upgrades,
+                               {
+                                 squads: [:embarked_transport, :squads_in_transport, available_unit: { unit: :transport_allowed_units }],
+                                 active_units: { unit: [:transport_allowed_units, :unit_vet] },
+                                 active_offmaps: :offmap,
+                                 company_offmaps: :offmap,
+                                 company_callin_modifiers: :callin_modifier,
+                                 squad_upgrades: :squad,
+                                 active_upgrades: :upgrade
+                               })
+                     .find_by(id: id, player: current_player)
       end
 
       def load_snapshot_company(uuid)

--- a/app/javascript/features/companies/manage/available_units/availableUnitsSlice.js
+++ b/app/javascript/features/companies/manage/available_units/availableUnitsSlice.js
@@ -47,15 +47,6 @@ const setStateForUnitTypes = (availableUnits, state) => {
   })
 }
 
-export const fetchCompanyAvailability = createAsyncThunk("availableUnits/fetchCompanyAvailability", async ({ companyId }, { rejectWithValue }) => {
-  try {
-    const response = await axios.get(`/companies/${companyId}/availability`)
-    return response.data
-  } catch (err) {
-    return rejectWithValue(err.response.data)
-  }
-})
-
 const availableUnitsSlice = createSlice({
   name: "availableUnits",
   initialState,

--- a/app/javascript/features/companies/manage/units/unitsSlice.jsx
+++ b/app/javascript/features/companies/manage/units/unitsSlice.jsx
@@ -1,6 +1,5 @@
 import { createAsyncThunk, createEntityAdapter, createSlice } from "@reduxjs/toolkit";
 import axios from "axios"
-import { fetchCompanyAvailability } from "../available_units/availableUnitsSlice";
 import { fetchCompanySquads, fetchSnapshotCompanySquads } from "./squadsSlice";
 
 const unitsAdapter = createEntityAdapter()

--- a/app/javascript/features/companies/manage/unlocks/CompanyUnlocks.jsx
+++ b/app/javascript/features/companies/manage/unlocks/CompanyUnlocks.jsx
@@ -6,7 +6,7 @@ import { fetchCompanyById, selectCompanyById, resetNeedsRefresh } from "../../co
 import { useParams, useLocation } from "react-router-dom";
 import { makeStyles } from "@mui/styles";
 import { fetchCompanySquads, resetSquadState } from "../units/squadsSlice";
-import { fetchCompanyAvailability, resetAvailableUnitState } from "../available_units/availableUnitsSlice";
+import { resetAvailableUnitState } from "../available_units/availableUnitsSlice";
 import {
   fetchDoctrineUnlocksByDoctrineId,
   selectDoctrineUnlockRowsByDoctrineId,

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -44,6 +44,10 @@ class Company < ApplicationRecord
   has_many :available_offmaps, dependent: :destroy
   has_many :available_upgrades, dependent: :destroy
 
+  has_many :active_units, -> { unit_active },  class_name: "AvailableUnit"
+  has_many :active_offmaps, -> { offmap_active }, class_name: "AvailableOffmap"
+  has_many :active_upgrades, -> { unit_active.upgrade_active }, class_name: "AvailableUpgrade"
+
   has_many :squads, dependent: :destroy
   has_many :squad_upgrades, through: :squads
   has_many :company_unlocks, dependent: :destroy

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe Company, type: :model do
 
     it { should have_many(:available_units) }
     it { should have_many(:available_offmaps) }
+    it { should have_many(:available_upgrades) }
+
+    it { should have_many(:active_units) }
+    it { should have_many(:active_offmaps) }
+    it { should have_many(:active_upgrades) }
 
     it { should have_many(:squads) }
     it { should have_many(:company_unlocks) }


### PR DESCRIPTION
We should return for a Company only the active Available Unit/Upgrade/Offmap entities (denoted by active root entities)

Removed /availability endpoint as not used