### PR TITLE
Skip creating platoon entries in battlefile for holding tab squads

### DIFF
--- a/app/helpers/company_helper.rb
+++ b/app/helpers/company_helper.rb
@@ -1,13 +1,14 @@
 module CompanyHelper
   # For a given company, return a table of squads arranged by tab_categories > category_position
-  # Tab_categories from Squad.tab_categories
+  # Tab_categories from Squad.tab_categories, but EXCLUDING holding
   # Category_positions are 0..7
   def self.get_platoon_table(company)
     table = Hash.new
 
     company.squads.each do |squad|
-      tab_category = squad.tab_category
+      next if squad.holding? # squads in holding cannot be spawned
 
+      tab_category = squad.tab_category
       if table.has_key?(tab_category)
         tab = table[tab_category]
       else

--- a/app/javascript/features/leaderboards/war_log/BattleHistory.jsx
+++ b/app/javascript/features/leaderboards/war_log/BattleHistory.jsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles(theme => ({
     overflowWrap: "normal"
   },
   battleId: {
-    textAlign: "center",
+    textAlign: "right",
     display: "flex"
   },
   links: {

--- a/app/services/battlefile_service.rb
+++ b/app/services/battlefile_service.rb
@@ -183,6 +183,8 @@ end
 
     result = ""
     platoons_table.each do |tab_category, platoons|
+      next if tab_category == Squad.tab_categories[:holding]
+
       platoons.each do |category_position, platoon|
         result << build_platoon_block(platoon, team_index, player_index, callin_modifiers)
       end


### PR DESCRIPTION
The battlefile requires platoons to have a platoon id readable by the game for spawning in the correct tab. However, the `holding` tab category was arbitrarily given an id of 0, which the game does not recognize. We should not create platoon entries in the battlefile for squads in holding.