### PR TITLE
downcase slot item refs in stats service

### DIFF
--- a/app/models/stats_upgrade.rb
+++ b/app/models/stats_upgrade.rb
@@ -33,7 +33,7 @@ class StatsUpgrade < ApplicationRecord
   end
 
   def added_slot_items_refs
-    data["actions"].filter { |a| a["reference"] == "slot_item_add" }.map { |a| a["slot_item"] }.compact
+    data["actions"].filter { |a| a["reference"] == "slot_item_add" }.map { |a| a["slot_item"]&.downcase }.compact
   end
 
   def entity

--- a/app/services/stats_units_service.rb
+++ b/app/services/stats_units_service.rb
@@ -157,14 +157,14 @@ class StatsUnitsService < ApplicationService
   def weapon_upgrade_slot_items_by_reference
     @_weapon_upgrade_slot_items_by_reference ||=
       begin
-        slot_item_refs = weapon_upgrade_slot_item_refs_by_upgrade_const.values.flatten.compact.uniq
+        slot_item_refs = weapon_upgrade_slot_item_refs_by_upgrade_const.values.flatten.compact.uniq.map(&:downcase)
         stats_slot_items = StatsSlotItem.where(ruleset_id: ruleset_id, reference: slot_item_refs)
         stats_slot_items.map { |si| [si.reference, si] }.to_h
       end
   end
 
   def dig_slot_item_weapon(slot_item)
-    slot_item.data.dig("weapon", "weapon")
+    slot_item.data.dig("weapon", "weapon")&.downcase
   end
 
   def loadout


### PR DESCRIPTION
Luft LMG34 slot item ref is not always downcased in stats data. This breaks the link to the StatsSlotItem reference which is downcased always.