### PR TITLE
Make player name required, update authentication controller

### DIFF
--- a/db/migrate/20250411224053_update_player_name_required.rb
+++ b/db/migrate/20250411224053_update_player_name_required.rb
@@ -1,0 +1,5 @@
+class UpdatePlayerNameRequired < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :players, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_02_031543) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_11_224053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -399,7 +399,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_02_031543) do
   end
 
   create_table "players", comment: "Player record", force: :cascade do |t|
-    t.string "name", comment: "Player screen name"
+    t.string "name", null: false, comment: "Player screen name"
     t.text "avatar", comment: "Player avatar url"
     t.string "provider", comment: "Omniauth provider"
     t.string "uid", comment: "Omniauth uid"


### PR DESCRIPTION
![stack](https://github.com/user-attachments/assets/1eb3ad02-2a66-45ec-88d1-46bf49cd7444)
Seems like the Steam OpenID service was degraded for a period of time which resulted in erroneous player updates for players who authenticated in that window.